### PR TITLE
Cleaner: `storageSyncSubscription` - add step to remove registered servers

### DIFF
--- a/clients/client.go
+++ b/clients/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/resourcegroups"
 	serviceBus "github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/cloudendpointresource"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/syncgroupresource"
 	webResourceProviders "github.com/hashicorp/go-azure-sdk/resource-manager/web/2024-04-01/resourceproviders"
@@ -75,8 +76,9 @@ type ResourceManagerClient struct {
 	RecoveryServicesBackupProtectedItemsClient *backupprotecteditems.BackupProtectedItemsClient
 	ServiceBus                                 *serviceBus.Client
 	StorageSyncClient                          *storagesyncservicesresource.StorageSyncServicesResourceClient
-	StorageSyncGroupClient                     *syncgroupresource.SyncGroupResourceClient
 	StorageSyncCloudEndpointClient             *cloudendpointresource.CloudEndpointResourceClient
+	StorageSyncGroupClient                     *syncgroupresource.SyncGroupResourceClient
+	StorageSyncRegisteredServerClient          *registeredserverresource.RegisteredServerResourceClient
 	WebResourceProviderClient                  *webResourceProviders.ResourceProvidersClient
 }
 
@@ -342,6 +344,12 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 	}
 	storageSyncCloudEndpointClient.Client.Authorizer = resourceManagerAuthorizer
 
+	storageSyncRegisteredServerClient, err := registeredserverresource.NewRegisteredServerResourceClientWithBaseURI(environment.ResourceManager)
+	if err != nil {
+		return nil, fmt.Errorf("building RegisteredServerResource Client: %+v", err)
+	}
+	storageSyncRegisteredServerClient.Client.Authorizer = resourceManagerAuthorizer
+
 	return &ResourceManagerClient{
 		DataProtection:                             dataProtectionClient,
 		EventHubDisasterRecoveryClient:             eventHubDisasterRecoveryClient,
@@ -368,6 +376,7 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 		StorageSyncClient:                          storageSyncClient,
 		StorageSyncGroupClient:                     storageSyncGroupClient,
 		StorageSyncCloudEndpointClient:             storageSyncCloudEndpointClient,
+		StorageSyncRegisteredServerClient:          storageSyncRegisteredServerClient,
 		WebResourceProviderClient:                  webResourceProvidersClient,
 	}, nil
 }

--- a/dalek/cleaners/subscriptions_delete_storage_sync.go
+++ b/dalek/cleaners/subscriptions_delete_storage_sync.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/cloudendpointresource"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/syncgroupresource"
 	"github.com/jackofallops/azurerm-dalek/clients"
@@ -27,6 +28,7 @@ func (p deleteStorageSyncSubscriptionCleaner) Cleanup(ctx context.Context, subsc
 	storageSyncClient := client.ResourceManager.StorageSyncClient
 	storageSyncGroupClient := client.ResourceManager.StorageSyncGroupClient
 	storageSyncCloudEndpointClient := client.ResourceManager.StorageSyncCloudEndpointClient
+	storageSyncRegisteredServerClient := client.ResourceManager.StorageSyncRegisteredServerClient
 
 	errs := make([]error, 0)
 
@@ -44,25 +46,60 @@ func (p deleteStorageSyncSubscriptionCleaner) Cleanup(ctx context.Context, subsc
 			continue
 		}
 
-		storageSyncForGroupId, err := syncgroupresource.ParseStorageSyncServiceID(*storageSync.Id)
+		id, err := storagesyncservicesresource.ParseStorageSyncServiceID(*storageSync.Id)
 		if err != nil {
 			errs = append(errs, err)
 			continue
 		}
 
-		if !strings.HasPrefix(storageSyncForGroupId.ResourceGroupName, opts.Prefix) {
-			log.Printf("[DEBUG] Not deleting %q as it does not match target RG prefix %q", *storageSyncForGroupId, opts.Prefix)
+		if !strings.HasPrefix(id.ResourceGroupName, opts.Prefix) {
+			log.Printf("[DEBUG] Not deleting %q as it does not match target RG prefix %q", *id, opts.Prefix)
 			continue
 		}
+
+		// Storage Sync Registered Servers Cleanup
+
+		registeredServers, err := storageSyncRegisteredServerClient.RegisteredServersListByStorageSyncService(ctx, registeredserverresource.StorageSyncServiceId(*id))
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if registeredServers.Model == nil || registeredServers.Model.Value == nil {
+			continue
+		}
+
+		for _, s := range *registeredServers.Model.Value {
+			if s.Id == nil {
+				continue
+			}
+
+			registeredServerID, err := registeredserverresource.ParseRegisteredServerID(*s.Id)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			if !opts.ActuallyDelete {
+				log.Printf("[DEBUG] Would have deleted %s", registeredServerID)
+				continue
+			}
+
+			if err := storageSyncRegisteredServerClient.RegisteredServersDeleteThenPoll(ctx, *registeredServerID); err != nil {
+				errs = append(errs, fmt.Errorf("deleting %s: %w", registeredServerID, err))
+			}
+		}
+
+		// Storage Sync Group Cleanup
 
 		if !opts.ActuallyDelete {
-			log.Printf("[DEBUG] Would have deleted %s..", storageSyncForGroupId)
+			log.Printf("[DEBUG] Would have deleted %s..", id)
 			continue
 		}
 
-		groupList, err := storageSyncGroupClient.SyncGroupsListByStorageSyncService(ctx, *storageSyncForGroupId)
+		groupList, err := storageSyncGroupClient.SyncGroupsListByStorageSyncService(ctx, syncgroupresource.StorageSyncServiceId(*id))
 		if err != nil {
-			errs = append(errs, fmt.Errorf("listing storage sync groups for %s: %+v", storageSyncForGroupId, err))
+			errs = append(errs, fmt.Errorf("listing storage sync groups for %s: %+v", id, err))
 		}
 
 		if groupList.Model == nil || groupList.Model.Value == nil {
@@ -127,6 +164,8 @@ func (p deleteStorageSyncSubscriptionCleaner) Cleanup(ctx context.Context, subsc
 				errs = append(errs, fmt.Errorf("deleting %s: %+v", groupId, err))
 			}
 		}
+
+		// Storage Sync Service Cleanup
 
 		storageSyncId, err := storagesyncservicesresource.ParseStorageSyncServiceID(*storageSync.Id)
 		if err != nil {

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/README.md
@@ -1,0 +1,98 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource` Documentation
+
+The `registeredserverresource` SDK allows for interaction with Azure Resource Manager `storagesync` (API Version `2020-03-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource"
+```
+
+
+### Client Initialization
+
+```go
+client := registeredserverresource.NewRegisteredServerResourceClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `RegisteredServerResourceClient.RegisteredServersCreate`
+
+```go
+ctx := context.TODO()
+id := registeredserverresource.NewRegisteredServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageSyncServiceName", "serverId")
+
+payload := registeredserverresource.RegisteredServerCreateParameters{
+	// ...
+}
+
+
+if err := client.RegisteredServersCreateThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RegisteredServerResourceClient.RegisteredServersDelete`
+
+```go
+ctx := context.TODO()
+id := registeredserverresource.NewRegisteredServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageSyncServiceName", "serverId")
+
+if err := client.RegisteredServersDeleteThenPoll(ctx, id); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `RegisteredServerResourceClient.RegisteredServersGet`
+
+```go
+ctx := context.TODO()
+id := registeredserverresource.NewRegisteredServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageSyncServiceName", "serverId")
+
+read, err := client.RegisteredServersGet(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `RegisteredServerResourceClient.RegisteredServersListByStorageSyncService`
+
+```go
+ctx := context.TODO()
+id := registeredserverresource.NewStorageSyncServiceID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageSyncServiceName")
+
+read, err := client.RegisteredServersListByStorageSyncService(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `RegisteredServerResourceClient.RegisteredServerstriggerRollover`
+
+```go
+ctx := context.TODO()
+id := registeredserverresource.NewRegisteredServerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "storageSyncServiceName", "serverId")
+
+payload := registeredserverresource.TriggerRolloverRequest{
+	// ...
+}
+
+
+if err := client.RegisteredServerstriggerRolloverThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/client.go
@@ -1,0 +1,26 @@
+package registeredserverresource
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	sdkEnv "github.com/hashicorp/go-azure-sdk/sdk/environments"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerResourceClient struct {
+	Client *resourcemanager.Client
+}
+
+func NewRegisteredServerResourceClientWithBaseURI(sdkApi sdkEnv.Api) (*RegisteredServerResourceClient, error) {
+	client, err := resourcemanager.NewClient(sdkApi, "registeredserverresource", defaultApiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("instantiating RegisteredServerResourceClient: %+v", err)
+	}
+
+	return &RegisteredServerResourceClient{
+		Client: client,
+	}, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/constants.go
@@ -1,0 +1,57 @@
+package registeredserverresource
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerAgentVersionStatus string
+
+const (
+	RegisteredServerAgentVersionStatusBlocked    RegisteredServerAgentVersionStatus = "Blocked"
+	RegisteredServerAgentVersionStatusExpired    RegisteredServerAgentVersionStatus = "Expired"
+	RegisteredServerAgentVersionStatusNearExpiry RegisteredServerAgentVersionStatus = "NearExpiry"
+	RegisteredServerAgentVersionStatusOk         RegisteredServerAgentVersionStatus = "Ok"
+)
+
+func PossibleValuesForRegisteredServerAgentVersionStatus() []string {
+	return []string{
+		string(RegisteredServerAgentVersionStatusBlocked),
+		string(RegisteredServerAgentVersionStatusExpired),
+		string(RegisteredServerAgentVersionStatusNearExpiry),
+		string(RegisteredServerAgentVersionStatusOk),
+	}
+}
+
+func (s *RegisteredServerAgentVersionStatus) UnmarshalJSON(bytes []byte) error {
+	var decoded string
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+	out, err := parseRegisteredServerAgentVersionStatus(decoded)
+	if err != nil {
+		return fmt.Errorf("parsing %q: %+v", decoded, err)
+	}
+	*s = *out
+	return nil
+}
+
+func parseRegisteredServerAgentVersionStatus(input string) (*RegisteredServerAgentVersionStatus, error) {
+	vals := map[string]RegisteredServerAgentVersionStatus{
+		"blocked":    RegisteredServerAgentVersionStatusBlocked,
+		"expired":    RegisteredServerAgentVersionStatusExpired,
+		"nearexpiry": RegisteredServerAgentVersionStatusNearExpiry,
+		"ok":         RegisteredServerAgentVersionStatusOk,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := RegisteredServerAgentVersionStatus(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/id_registeredserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/id_registeredserver.go
@@ -1,0 +1,139 @@
+package registeredserverresource
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&RegisteredServerId{})
+}
+
+var _ resourceids.ResourceId = &RegisteredServerId{}
+
+// RegisteredServerId is a struct representing the Resource ID for a Registered Server
+type RegisteredServerId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	StorageSyncServiceName string
+	ServerId               string
+}
+
+// NewRegisteredServerID returns a new RegisteredServerId struct
+func NewRegisteredServerID(subscriptionId string, resourceGroupName string, storageSyncServiceName string, serverId string) RegisteredServerId {
+	return RegisteredServerId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		StorageSyncServiceName: storageSyncServiceName,
+		ServerId:               serverId,
+	}
+}
+
+// ParseRegisteredServerID parses 'input' into a RegisteredServerId
+func ParseRegisteredServerID(input string) (*RegisteredServerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RegisteredServerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RegisteredServerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseRegisteredServerIDInsensitively parses 'input' case-insensitively into a RegisteredServerId
+// note: this method should only be used for API response data and not user input
+func ParseRegisteredServerIDInsensitively(input string) (*RegisteredServerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&RegisteredServerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := RegisteredServerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *RegisteredServerId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.StorageSyncServiceName, ok = input.Parsed["storageSyncServiceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "storageSyncServiceName", input)
+	}
+
+	if id.ServerId, ok = input.Parsed["serverId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "serverId", input)
+	}
+
+	return nil
+}
+
+// ValidateRegisteredServerID checks that 'input' can be parsed as a Registered Server ID
+func ValidateRegisteredServerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseRegisteredServerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Registered Server ID
+func (id RegisteredServerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.StorageSync/storageSyncServices/%s/registeredServers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.StorageSyncServiceName, id.ServerId)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Registered Server ID
+func (id RegisteredServerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStorageSync", "Microsoft.StorageSync", "Microsoft.StorageSync"),
+		resourceids.StaticSegment("staticStorageSyncServices", "storageSyncServices", "storageSyncServices"),
+		resourceids.UserSpecifiedSegment("storageSyncServiceName", "storageSyncServiceName"),
+		resourceids.StaticSegment("staticRegisteredServers", "registeredServers", "registeredServers"),
+		resourceids.UserSpecifiedSegment("serverId", "serverId"),
+	}
+}
+
+// String returns a human-readable description of this Registered Server ID
+func (id RegisteredServerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Storage Sync Service Name: %q", id.StorageSyncServiceName),
+		fmt.Sprintf("Server: %q", id.ServerId),
+	}
+	return fmt.Sprintf("Registered Server (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/id_storagesyncservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/id_storagesyncservice.go
@@ -1,0 +1,130 @@
+package registeredserverresource
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&StorageSyncServiceId{})
+}
+
+var _ resourceids.ResourceId = &StorageSyncServiceId{}
+
+// StorageSyncServiceId is a struct representing the Resource ID for a Storage Sync Service
+type StorageSyncServiceId struct {
+	SubscriptionId         string
+	ResourceGroupName      string
+	StorageSyncServiceName string
+}
+
+// NewStorageSyncServiceID returns a new StorageSyncServiceId struct
+func NewStorageSyncServiceID(subscriptionId string, resourceGroupName string, storageSyncServiceName string) StorageSyncServiceId {
+	return StorageSyncServiceId{
+		SubscriptionId:         subscriptionId,
+		ResourceGroupName:      resourceGroupName,
+		StorageSyncServiceName: storageSyncServiceName,
+	}
+}
+
+// ParseStorageSyncServiceID parses 'input' into a StorageSyncServiceId
+func ParseStorageSyncServiceID(input string) (*StorageSyncServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&StorageSyncServiceId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := StorageSyncServiceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseStorageSyncServiceIDInsensitively parses 'input' case-insensitively into a StorageSyncServiceId
+// note: this method should only be used for API response data and not user input
+func ParseStorageSyncServiceIDInsensitively(input string) (*StorageSyncServiceId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&StorageSyncServiceId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := StorageSyncServiceId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *StorageSyncServiceId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.StorageSyncServiceName, ok = input.Parsed["storageSyncServiceName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "storageSyncServiceName", input)
+	}
+
+	return nil
+}
+
+// ValidateStorageSyncServiceID checks that 'input' can be parsed as a Storage Sync Service ID
+func ValidateStorageSyncServiceID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseStorageSyncServiceID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Storage Sync Service ID
+func (id StorageSyncServiceId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.StorageSync/storageSyncServices/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.StorageSyncServiceName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Storage Sync Service ID
+func (id StorageSyncServiceId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftStorageSync", "Microsoft.StorageSync", "Microsoft.StorageSync"),
+		resourceids.StaticSegment("staticStorageSyncServices", "storageSyncServices", "storageSyncServices"),
+		resourceids.UserSpecifiedSegment("storageSyncServiceName", "storageSyncServiceName"),
+	}
+}
+
+// String returns a human-readable description of this Storage Sync Service ID
+func (id StorageSyncServiceId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Storage Sync Service Name: %q", id.StorageSyncServiceName),
+	}
+	return fmt.Sprintf("Storage Sync Service (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverscreate.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverscreate.go
@@ -1,0 +1,75 @@
+package registeredserverresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServersCreateOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RegisteredServer
+}
+
+// RegisteredServersCreate ...
+func (c RegisteredServerResourceClient) RegisteredServersCreate(ctx context.Context, id RegisteredServerId, input RegisteredServerCreateParameters) (result RegisteredServersCreateOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegisteredServersCreateThenPoll performs RegisteredServersCreate then polls until it's completed
+func (c RegisteredServerResourceClient) RegisteredServersCreateThenPoll(ctx context.Context, id RegisteredServerId, input RegisteredServerCreateParameters) error {
+	result, err := c.RegisteredServersCreate(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegisteredServersCreate: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegisteredServersCreate: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserversdelete.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserversdelete.go
@@ -1,0 +1,71 @@
+package registeredserverresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServersDeleteOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegisteredServersDelete ...
+func (c RegisteredServerResourceClient) RegisteredServersDelete(ctx context.Context, id RegisteredServerId) (result RegisteredServersDeleteOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusNoContent,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodDelete,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegisteredServersDeleteThenPoll performs RegisteredServersDelete then polls until it's completed
+func (c RegisteredServerResourceClient) RegisteredServersDeleteThenPoll(ctx context.Context, id RegisteredServerId) error {
+	result, err := c.RegisteredServersDelete(ctx, id)
+	if err != nil {
+		return fmt.Errorf("performing RegisteredServersDelete: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegisteredServersDelete: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserversget.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserversget.go
@@ -1,0 +1,53 @@
+package registeredserverresource
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServersGetOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RegisteredServer
+}
+
+// RegisteredServersGet ...
+func (c RegisteredServerResourceClient) RegisteredServersGet(ctx context.Context, id RegisteredServerId) (result RegisteredServersGetOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       id.ID(),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RegisteredServer
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverslistbystoragesyncservice.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverslistbystoragesyncservice.go
@@ -1,0 +1,54 @@
+package registeredserverresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServersListByStorageSyncServiceOperationResponse struct {
+	HttpResponse *http.Response
+	OData        *odata.OData
+	Model        *RegisteredServerArray
+}
+
+// RegisteredServersListByStorageSyncService ...
+func (c RegisteredServerResourceClient) RegisteredServersListByStorageSyncService(ctx context.Context, id StorageSyncServiceId) (result RegisteredServersListByStorageSyncServiceOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		Path:       fmt.Sprintf("%s/registeredServers", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	var model RegisteredServerArray
+	result.Model = &model
+	if err = resp.Unmarshal(result.Model); err != nil {
+		return
+	}
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverstriggerrollover.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/method_registeredserverstriggerrollover.go
@@ -1,0 +1,74 @@
+package registeredserverresource
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/resourcemanager"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerstriggerRolloverOperationResponse struct {
+	Poller       pollers.Poller
+	HttpResponse *http.Response
+	OData        *odata.OData
+}
+
+// RegisteredServerstriggerRollover ...
+func (c RegisteredServerResourceClient) RegisteredServerstriggerRollover(ctx context.Context, id RegisteredServerId, input TriggerRolloverRequest) (result RegisteredServerstriggerRolloverOperationResponse, err error) {
+	opts := client.RequestOptions{
+		ContentType: "application/json; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPost,
+		Path:       fmt.Sprintf("%s/triggerRollover", id.ID()),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		return
+	}
+
+	if err = req.Marshal(input); err != nil {
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.OData = resp.OData
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		return
+	}
+
+	result.Poller, err = resourcemanager.PollerFromResponse(resp, c.Client)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// RegisteredServerstriggerRolloverThenPoll performs RegisteredServerstriggerRollover then polls until it's completed
+func (c RegisteredServerResourceClient) RegisteredServerstriggerRolloverThenPoll(ctx context.Context, id RegisteredServerId, input TriggerRolloverRequest) error {
+	result, err := c.RegisteredServerstriggerRollover(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing RegisteredServerstriggerRollover: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("polling after RegisteredServerstriggerRollover: %+v", err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserver.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserver.go
@@ -1,0 +1,11 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServer struct {
+	Id         *string                     `json:"id,omitempty"`
+	Name       *string                     `json:"name,omitempty"`
+	Properties *RegisteredServerProperties `json:"properties,omitempty"`
+	Type       *string                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserverarray.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserverarray.go
@@ -1,0 +1,8 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerArray struct {
+	Value *[]RegisteredServer `json:"value,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredservercreateparameters.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredservercreateparameters.go
@@ -1,0 +1,11 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerCreateParameters struct {
+	Id         *string                                     `json:"id,omitempty"`
+	Name       *string                                     `json:"name,omitempty"`
+	Properties *RegisteredServerCreateParametersProperties `json:"properties,omitempty"`
+	Type       *string                                     `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredservercreateparametersproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredservercreateparametersproperties.go
@@ -1,0 +1,16 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerCreateParametersProperties struct {
+	AgentVersion      *string `json:"agentVersion,omitempty"`
+	ClusterId         *string `json:"clusterId,omitempty"`
+	ClusterName       *string `json:"clusterName,omitempty"`
+	FriendlyName      *string `json:"friendlyName,omitempty"`
+	LastHeartBeat     *string `json:"lastHeartBeat,omitempty"`
+	ServerCertificate *string `json:"serverCertificate,omitempty"`
+	ServerId          *string `json:"serverId,omitempty"`
+	ServerOSVersion   *string `json:"serverOSVersion,omitempty"`
+	ServerRole        *string `json:"serverRole,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserverproperties.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_registeredserverproperties.go
@@ -1,0 +1,47 @@
+package registeredserverresource
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisteredServerProperties struct {
+	AgentVersion               *string                             `json:"agentVersion,omitempty"`
+	AgentVersionExpirationDate *string                             `json:"agentVersionExpirationDate,omitempty"`
+	AgentVersionStatus         *RegisteredServerAgentVersionStatus `json:"agentVersionStatus,omitempty"`
+	ClusterId                  *string                             `json:"clusterId,omitempty"`
+	ClusterName                *string                             `json:"clusterName,omitempty"`
+	DiscoveryEndpointUri       *string                             `json:"discoveryEndpointUri,omitempty"`
+	FriendlyName               *string                             `json:"friendlyName,omitempty"`
+	LastHeartBeat              *string                             `json:"lastHeartBeat,omitempty"`
+	LastOperationName          *string                             `json:"lastOperationName,omitempty"`
+	LastWorkflowId             *string                             `json:"lastWorkflowId,omitempty"`
+	ManagementEndpointUri      *string                             `json:"managementEndpointUri,omitempty"`
+	MonitoringConfiguration    *string                             `json:"monitoringConfiguration,omitempty"`
+	MonitoringEndpointUri      *string                             `json:"monitoringEndpointUri,omitempty"`
+	ProvisioningState          *string                             `json:"provisioningState,omitempty"`
+	ResourceLocation           *string                             `json:"resourceLocation,omitempty"`
+	ServerCertificate          *string                             `json:"serverCertificate,omitempty"`
+	ServerId                   *string                             `json:"serverId,omitempty"`
+	ServerManagementErrorCode  *int64                              `json:"serverManagementErrorCode,omitempty"`
+	ServerOSVersion            *string                             `json:"serverOSVersion,omitempty"`
+	ServerRole                 *string                             `json:"serverRole,omitempty"`
+	ServiceLocation            *string                             `json:"serviceLocation,omitempty"`
+	StorageSyncServiceUid      *string                             `json:"storageSyncServiceUid,omitempty"`
+}
+
+func (o *RegisteredServerProperties) GetAgentVersionExpirationDateAsTime() (*time.Time, error) {
+	if o.AgentVersionExpirationDate == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.AgentVersionExpirationDate, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *RegisteredServerProperties) SetAgentVersionExpirationDateAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.AgentVersionExpirationDate = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_triggerrolloverrequest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/model_triggerrolloverrequest.go
@@ -1,0 +1,8 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type TriggerRolloverRequest struct {
+	ServerCertificate *string `json:"serverCertificate,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource/version.go
@@ -1,0 +1,10 @@
+package registeredserverresource
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2020-03-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/registeredserverresource/2020-03-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,6 +117,7 @@ github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview
 github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview/topics
 github.com/hashicorp/go-azure-sdk/resource-manager/servicebus/2022-01-01-preview/topicsauthorizationrule
 github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/cloudendpointresource
+github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/registeredserverresource
 github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/storagesyncservicesresource
 github.com/hashicorp/go-azure-sdk/resource-manager/storagesync/2020-03-01/syncgroupresource
 github.com/hashicorp/go-azure-sdk/resource-manager/web/2024-04-01/resourceproviders


### PR DESCRIPTION
Storage Sync resources can't be deleted when there are registered servers, added a step to unregister any servers if present before attempting service deletion.