### PR TITLE
Cleaner: `RecoveryServicesVault` - add step to remove protection containers

### DIFF
--- a/clients/client.go
+++ b/clients/client.go
@@ -25,7 +25,9 @@ import (
 	paloAltoNetworks "github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-10-01/vaults"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotecteditems"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protecteditems"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers"
 	resourceGraph "github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/resourcegroups"
@@ -81,6 +83,8 @@ type ResourceManagerClient struct {
 	RecoveryServicesVaultClient                *vaults.VaultsClient
 	RecoveryServicesProtectedItemClient        *protecteditems.ProtectedItemsClient
 	RecoveryServicesBackupProtectedItemsClient *backupprotecteditems.BackupProtectedItemsClient
+	RecoveryServicesBackupProtectionContainers *backupprotectioncontainers.BackupProtectionContainersClient
+	RecoveryServicesProtectionContainers       *protectioncontainers.ProtectionContainersClient
 	ServiceBus                                 *serviceBus.Client
 	StorageSyncClient                          *storagesyncservicesresource.StorageSyncServicesResourceClient
 	StorageSyncCloudEndpointClient             *cloudendpointresource.CloudEndpointResourceClient
@@ -338,6 +342,12 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 	recoveryServicesBackupProtectedItemsClient := backupprotecteditems.NewBackupProtectedItemsClientWithBaseURI(*resourceManagerEndpoint)
 	recoveryServicesBackupProtectedItemsClient.Client.Authorizer = autoRestAuthorizer
 
+	recoveryServicesBackupProtectionContainersClient := backupprotectioncontainers.NewBackupProtectionContainersClientWithBaseURI(*resourceManagerEndpoint)
+	recoveryServicesBackupProtectionContainersClient.Client.Authorizer = autoRestAuthorizer
+
+	recoveryServicesProtectionContainers := protectioncontainers.NewProtectionContainersClientWithBaseURI(*resourceManagerEndpoint)
+	recoveryServicesProtectionContainers.Client.Authorizer = autoRestAuthorizer
+
 	resourceGraphClient, err := resourceGraph.NewResourcesClientWithBaseURI(environment.ResourceManager)
 	if err != nil {
 		return nil, fmt.Errorf("building ResourceGraph client: %+v", err)
@@ -411,6 +421,8 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 		ResourceGraphClient:                        resourceGraphClient,
 		ResourcesGroupsClient:                      resourcesClient,
 		RecoveryServicesBackupProtectedItemsClient: &recoveryServicesBackupProtectedItemsClient,
+		RecoveryServicesBackupProtectionContainers: &recoveryServicesBackupProtectionContainersClient,
+		RecoveryServicesProtectionContainers:       &recoveryServicesProtectionContainers,
 		RecoveryServicesProtectedItemClient:        &recoveryServicesProtectedItemClient,
 		RecoveryServicesVaultClient:                recoveryServicesVaultClient,
 		ServiceBus:                                 serviceBusClient,

--- a/dalek/cleaners/subscriptions_delete_recovery_services_vault.go
+++ b/dalek/cleaners/subscriptions_delete_recovery_services_vault.go
@@ -9,7 +9,9 @@ import (
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-10-01/vaults"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotecteditems"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protecteditems"
+	"github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers"
 	"github.com/jackofallops/azurerm-dalek/clients"
 	"github.com/jackofallops/azurerm-dalek/dalek/options"
 )
@@ -26,6 +28,8 @@ func (p deleteRecoveryServicesVaultSubscriptionCleaner) Cleanup(ctx context.Cont
 	vaultsClient := client.ResourceManager.RecoveryServicesVaultClient
 	protectedItemsClient := client.ResourceManager.RecoveryServicesProtectedItemClient
 	backupProtectedItemsClient := client.ResourceManager.RecoveryServicesBackupProtectedItemsClient
+	backupProtectionContainersClient := client.ResourceManager.RecoveryServicesBackupProtectionContainers
+	protectionContainersClient := client.ResourceManager.RecoveryServicesProtectionContainers
 
 	errs := make([]error, 0)
 
@@ -109,6 +113,30 @@ func (p deleteRecoveryServicesVaultSubscriptionCleaner) Cleanup(ctx context.Cont
 			_, err = protectedItemsClient.Delete(ctx, *backupItemId)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("[DEBUG] deleting %q: %+v", backupItemId, err))
+				continue
+			}
+		}
+
+		// Unregister Protection Containers, prerequisite to vault deletion
+		storageContainers, err := backupProtectionContainersClient.ListComplete(ctx, backupprotectioncontainers.VaultId(*backupItemsVaultId), backupprotectioncontainers.ListOperationOptions{Filter: pointer.To("backupManagementType eq 'AzureStorage'")})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("listing %s: %w", *backupItemsVaultId, err))
+			continue
+		}
+
+		for _, sc := range storageContainers.Items {
+			if sc.Id == nil {
+				continue
+			}
+
+			scID, err := protectioncontainers.ParseProtectionContainerID(*sc.Id)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+
+			if _, err := protectionContainersClient.Unregister(ctx, *scID); err != nil {
+				errs = append(errs, fmt.Errorf("unregistering %s: %w", scID, err))
 				continue
 			}
 		}

--- a/vendor/github.com/hashicorp/go-azure-helpers/polling/poller.go
+++ b/vendor/github.com/hashicorp/go-azure-helpers/polling/poller.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package polling
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+)
+
+type LongRunningPoller struct {
+	// HttpResponse is the latest HTTP Response
+	HttpResponse *http.Response
+
+	future *azure.Future
+	ctx    context.Context
+	client autorest.Client
+	method string
+}
+
+// NewLongRunningPollerFromResponse creates a new LongRunningPoller from the HTTP Response
+// this is deprecated and replaced by NewPollerFromResponse. Can be removed once all the
+// embedded SDKs have been removed.
+func NewLongRunningPollerFromResponse(ctx context.Context, resp *http.Response, client autorest.Client) (LongRunningPoller, error) {
+	poller := LongRunningPoller{
+		ctx:    ctx,
+		client: client,
+	}
+	future, err := azure.NewFutureFromResponse(resp)
+	if err != nil {
+		return poller, err
+	}
+	poller.future = &future
+	return poller, nil
+}
+
+// NewPollerFromResponse creates a new LongRunningPoller from the HTTP Response
+func NewPollerFromResponse(ctx context.Context, resp *http.Response, client autorest.Client, method string) (LongRunningPoller, error) {
+	poller := LongRunningPoller{
+		ctx:    ctx,
+		client: client,
+		method: method,
+	}
+	future, err := azure.NewFutureFromResponse(resp)
+	if err != nil {
+		return poller, err
+	}
+	poller.future = &future
+	return poller, nil
+}
+
+// PollUntilDone polls until this Long Running Poller is completed
+func (fw *LongRunningPoller) PollUntilDone() error {
+	if fw.future == nil {
+		return fmt.Errorf("internal error: cannot poll on a nil-future")
+	}
+
+	err := fw.future.WaitForCompletionRef(fw.ctx, fw.client)
+	fw.HttpResponse = fw.future.Response()
+	if strings.EqualFold(fw.method, "DELETE") {
+		if response.WasNotFound(fw.HttpResponse) {
+			err = nil
+		}
+	}
+	return err
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/README.md
@@ -1,0 +1,37 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers` Documentation
+
+The `backupprotectioncontainers` SDK allows for interaction with Azure Resource Manager `recoveryservicesbackup` (API Version `2024-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers"
+```
+
+
+### Client Initialization
+
+```go
+client := backupprotectioncontainers.NewBackupProtectionContainersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `BackupProtectionContainersClient.List`
+
+```go
+ctx := context.TODO()
+id := backupprotectioncontainers.NewVaultID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName")
+
+// alternatively `client.List(ctx, id, backupprotectioncontainers.DefaultListOperationOptions())` can be used to do batched pagination
+items, err := client.ListComplete(ctx, id, backupprotectioncontainers.DefaultListOperationOptions())
+if err != nil {
+	// handle the error
+}
+for _, item := range items {
+	// do something
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/client.go
@@ -1,0 +1,18 @@
+package backupprotectioncontainers
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type BackupProtectionContainersClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewBackupProtectionContainersClientWithBaseURI(endpoint string) BackupProtectionContainersClient {
+	return BackupProtectionContainersClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/constants.go
@@ -1,0 +1,335 @@
+package backupprotectioncontainers
+
+import (
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AcquireStorageAccountLock string
+
+const (
+	AcquireStorageAccountLockAcquire    AcquireStorageAccountLock = "Acquire"
+	AcquireStorageAccountLockNotAcquire AcquireStorageAccountLock = "NotAcquire"
+)
+
+func PossibleValuesForAcquireStorageAccountLock() []string {
+	return []string{
+		string(AcquireStorageAccountLockAcquire),
+		string(AcquireStorageAccountLockNotAcquire),
+	}
+}
+
+func parseAcquireStorageAccountLock(input string) (*AcquireStorageAccountLock, error) {
+	vals := map[string]AcquireStorageAccountLock{
+		"acquire":    AcquireStorageAccountLockAcquire,
+		"notacquire": AcquireStorageAccountLockNotAcquire,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AcquireStorageAccountLock(input)
+	return &out, nil
+}
+
+type BackupItemType string
+
+const (
+	BackupItemTypeAzureFileShare    BackupItemType = "AzureFileShare"
+	BackupItemTypeAzureSqlDb        BackupItemType = "AzureSqlDb"
+	BackupItemTypeClient            BackupItemType = "Client"
+	BackupItemTypeExchange          BackupItemType = "Exchange"
+	BackupItemTypeFileFolder        BackupItemType = "FileFolder"
+	BackupItemTypeGenericDataSource BackupItemType = "GenericDataSource"
+	BackupItemTypeInvalid           BackupItemType = "Invalid"
+	BackupItemTypeSAPAseDatabase    BackupItemType = "SAPAseDatabase"
+	BackupItemTypeSAPHanaDBInstance BackupItemType = "SAPHanaDBInstance"
+	BackupItemTypeSAPHanaDatabase   BackupItemType = "SAPHanaDatabase"
+	BackupItemTypeSQLDB             BackupItemType = "SQLDB"
+	BackupItemTypeSQLDataBase       BackupItemType = "SQLDataBase"
+	BackupItemTypeSharepoint        BackupItemType = "Sharepoint"
+	BackupItemTypeSystemState       BackupItemType = "SystemState"
+	BackupItemTypeVM                BackupItemType = "VM"
+	BackupItemTypeVMwareVM          BackupItemType = "VMwareVM"
+)
+
+func PossibleValuesForBackupItemType() []string {
+	return []string{
+		string(BackupItemTypeAzureFileShare),
+		string(BackupItemTypeAzureSqlDb),
+		string(BackupItemTypeClient),
+		string(BackupItemTypeExchange),
+		string(BackupItemTypeFileFolder),
+		string(BackupItemTypeGenericDataSource),
+		string(BackupItemTypeInvalid),
+		string(BackupItemTypeSAPAseDatabase),
+		string(BackupItemTypeSAPHanaDBInstance),
+		string(BackupItemTypeSAPHanaDatabase),
+		string(BackupItemTypeSQLDB),
+		string(BackupItemTypeSQLDataBase),
+		string(BackupItemTypeSharepoint),
+		string(BackupItemTypeSystemState),
+		string(BackupItemTypeVM),
+		string(BackupItemTypeVMwareVM),
+	}
+}
+
+func parseBackupItemType(input string) (*BackupItemType, error) {
+	vals := map[string]BackupItemType{
+		"azurefileshare":    BackupItemTypeAzureFileShare,
+		"azuresqldb":        BackupItemTypeAzureSqlDb,
+		"client":            BackupItemTypeClient,
+		"exchange":          BackupItemTypeExchange,
+		"filefolder":        BackupItemTypeFileFolder,
+		"genericdatasource": BackupItemTypeGenericDataSource,
+		"invalid":           BackupItemTypeInvalid,
+		"sapasedatabase":    BackupItemTypeSAPAseDatabase,
+		"saphanadbinstance": BackupItemTypeSAPHanaDBInstance,
+		"saphanadatabase":   BackupItemTypeSAPHanaDatabase,
+		"sqldb":             BackupItemTypeSQLDB,
+		"sqldatabase":       BackupItemTypeSQLDataBase,
+		"sharepoint":        BackupItemTypeSharepoint,
+		"systemstate":       BackupItemTypeSystemState,
+		"vm":                BackupItemTypeVM,
+		"vmwarevm":          BackupItemTypeVMwareVM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := BackupItemType(input)
+	return &out, nil
+}
+
+type BackupManagementType string
+
+const (
+	BackupManagementTypeAzureBackupServer BackupManagementType = "AzureBackupServer"
+	BackupManagementTypeAzureIaasVM       BackupManagementType = "AzureIaasVM"
+	BackupManagementTypeAzureSql          BackupManagementType = "AzureSql"
+	BackupManagementTypeAzureStorage      BackupManagementType = "AzureStorage"
+	BackupManagementTypeAzureWorkload     BackupManagementType = "AzureWorkload"
+	BackupManagementTypeDPM               BackupManagementType = "DPM"
+	BackupManagementTypeDefaultBackup     BackupManagementType = "DefaultBackup"
+	BackupManagementTypeInvalid           BackupManagementType = "Invalid"
+	BackupManagementTypeMAB               BackupManagementType = "MAB"
+)
+
+func PossibleValuesForBackupManagementType() []string {
+	return []string{
+		string(BackupManagementTypeAzureBackupServer),
+		string(BackupManagementTypeAzureIaasVM),
+		string(BackupManagementTypeAzureSql),
+		string(BackupManagementTypeAzureStorage),
+		string(BackupManagementTypeAzureWorkload),
+		string(BackupManagementTypeDPM),
+		string(BackupManagementTypeDefaultBackup),
+		string(BackupManagementTypeInvalid),
+		string(BackupManagementTypeMAB),
+	}
+}
+
+func parseBackupManagementType(input string) (*BackupManagementType, error) {
+	vals := map[string]BackupManagementType{
+		"azurebackupserver": BackupManagementTypeAzureBackupServer,
+		"azureiaasvm":       BackupManagementTypeAzureIaasVM,
+		"azuresql":          BackupManagementTypeAzureSql,
+		"azurestorage":      BackupManagementTypeAzureStorage,
+		"azureworkload":     BackupManagementTypeAzureWorkload,
+		"dpm":               BackupManagementTypeDPM,
+		"defaultbackup":     BackupManagementTypeDefaultBackup,
+		"invalid":           BackupManagementTypeInvalid,
+		"mab":               BackupManagementTypeMAB,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := BackupManagementType(input)
+	return &out, nil
+}
+
+type OperationType string
+
+const (
+	OperationTypeInvalid    OperationType = "Invalid"
+	OperationTypeRegister   OperationType = "Register"
+	OperationTypeRehydrate  OperationType = "Rehydrate"
+	OperationTypeReregister OperationType = "Reregister"
+)
+
+func PossibleValuesForOperationType() []string {
+	return []string{
+		string(OperationTypeInvalid),
+		string(OperationTypeRegister),
+		string(OperationTypeRehydrate),
+		string(OperationTypeReregister),
+	}
+}
+
+func parseOperationType(input string) (*OperationType, error) {
+	vals := map[string]OperationType{
+		"invalid":    OperationTypeInvalid,
+		"register":   OperationTypeRegister,
+		"rehydrate":  OperationTypeRehydrate,
+		"reregister": OperationTypeReregister,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationType(input)
+	return &out, nil
+}
+
+type ProtectableContainerType string
+
+const (
+	ProtectableContainerTypeAzureBackupServerContainer                  ProtectableContainerType = "AzureBackupServerContainer"
+	ProtectableContainerTypeAzureSqlContainer                           ProtectableContainerType = "AzureSqlContainer"
+	ProtectableContainerTypeAzureWorkloadContainer                      ProtectableContainerType = "AzureWorkloadContainer"
+	ProtectableContainerTypeCluster                                     ProtectableContainerType = "Cluster"
+	ProtectableContainerTypeDPMContainer                                ProtectableContainerType = "DPMContainer"
+	ProtectableContainerTypeGenericContainer                            ProtectableContainerType = "GenericContainer"
+	ProtectableContainerTypeIaasVMContainer                             ProtectableContainerType = "IaasVMContainer"
+	ProtectableContainerTypeIaasVMServiceContainer                      ProtectableContainerType = "IaasVMServiceContainer"
+	ProtectableContainerTypeInvalid                                     ProtectableContainerType = "Invalid"
+	ProtectableContainerTypeMABContainer                                ProtectableContainerType = "MABContainer"
+	ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines ProtectableContainerType = "Microsoft.ClassicCompute/virtualMachines"
+	ProtectableContainerTypeMicrosoftPointComputeVirtualMachines        ProtectableContainerType = "Microsoft.Compute/virtualMachines"
+	ProtectableContainerTypeSQLAGWorkLoadContainer                      ProtectableContainerType = "SQLAGWorkLoadContainer"
+	ProtectableContainerTypeStorageContainer                            ProtectableContainerType = "StorageContainer"
+	ProtectableContainerTypeUnknown                                     ProtectableContainerType = "Unknown"
+	ProtectableContainerTypeVCenter                                     ProtectableContainerType = "VCenter"
+	ProtectableContainerTypeVMAppContainer                              ProtectableContainerType = "VMAppContainer"
+	ProtectableContainerTypeWindows                                     ProtectableContainerType = "Windows"
+)
+
+func PossibleValuesForProtectableContainerType() []string {
+	return []string{
+		string(ProtectableContainerTypeAzureBackupServerContainer),
+		string(ProtectableContainerTypeAzureSqlContainer),
+		string(ProtectableContainerTypeAzureWorkloadContainer),
+		string(ProtectableContainerTypeCluster),
+		string(ProtectableContainerTypeDPMContainer),
+		string(ProtectableContainerTypeGenericContainer),
+		string(ProtectableContainerTypeIaasVMContainer),
+		string(ProtectableContainerTypeIaasVMServiceContainer),
+		string(ProtectableContainerTypeInvalid),
+		string(ProtectableContainerTypeMABContainer),
+		string(ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines),
+		string(ProtectableContainerTypeMicrosoftPointComputeVirtualMachines),
+		string(ProtectableContainerTypeSQLAGWorkLoadContainer),
+		string(ProtectableContainerTypeStorageContainer),
+		string(ProtectableContainerTypeUnknown),
+		string(ProtectableContainerTypeVCenter),
+		string(ProtectableContainerTypeVMAppContainer),
+		string(ProtectableContainerTypeWindows),
+	}
+}
+
+func parseProtectableContainerType(input string) (*ProtectableContainerType, error) {
+	vals := map[string]ProtectableContainerType{
+		"azurebackupservercontainer": ProtectableContainerTypeAzureBackupServerContainer,
+		"azuresqlcontainer":          ProtectableContainerTypeAzureSqlContainer,
+		"azureworkloadcontainer":     ProtectableContainerTypeAzureWorkloadContainer,
+		"cluster":                    ProtectableContainerTypeCluster,
+		"dpmcontainer":               ProtectableContainerTypeDPMContainer,
+		"genericcontainer":           ProtectableContainerTypeGenericContainer,
+		"iaasvmcontainer":            ProtectableContainerTypeIaasVMContainer,
+		"iaasvmservicecontainer":     ProtectableContainerTypeIaasVMServiceContainer,
+		"invalid":                    ProtectableContainerTypeInvalid,
+		"mabcontainer":               ProtectableContainerTypeMABContainer,
+		"microsoft.classiccompute/virtualmachines": ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines,
+		"microsoft.compute/virtualmachines":        ProtectableContainerTypeMicrosoftPointComputeVirtualMachines,
+		"sqlagworkloadcontainer":                   ProtectableContainerTypeSQLAGWorkLoadContainer,
+		"storagecontainer":                         ProtectableContainerTypeStorageContainer,
+		"unknown":                                  ProtectableContainerTypeUnknown,
+		"vcenter":                                  ProtectableContainerTypeVCenter,
+		"vmappcontainer":                           ProtectableContainerTypeVMAppContainer,
+		"windows":                                  ProtectableContainerTypeWindows,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtectableContainerType(input)
+	return &out, nil
+}
+
+type WorkloadType string
+
+const (
+	WorkloadTypeAzureFileShare    WorkloadType = "AzureFileShare"
+	WorkloadTypeAzureSqlDb        WorkloadType = "AzureSqlDb"
+	WorkloadTypeClient            WorkloadType = "Client"
+	WorkloadTypeExchange          WorkloadType = "Exchange"
+	WorkloadTypeFileFolder        WorkloadType = "FileFolder"
+	WorkloadTypeGenericDataSource WorkloadType = "GenericDataSource"
+	WorkloadTypeInvalid           WorkloadType = "Invalid"
+	WorkloadTypeSAPAseDatabase    WorkloadType = "SAPAseDatabase"
+	WorkloadTypeSAPHanaDBInstance WorkloadType = "SAPHanaDBInstance"
+	WorkloadTypeSAPHanaDatabase   WorkloadType = "SAPHanaDatabase"
+	WorkloadTypeSQLDB             WorkloadType = "SQLDB"
+	WorkloadTypeSQLDataBase       WorkloadType = "SQLDataBase"
+	WorkloadTypeSharepoint        WorkloadType = "Sharepoint"
+	WorkloadTypeSystemState       WorkloadType = "SystemState"
+	WorkloadTypeVM                WorkloadType = "VM"
+	WorkloadTypeVMwareVM          WorkloadType = "VMwareVM"
+)
+
+func PossibleValuesForWorkloadType() []string {
+	return []string{
+		string(WorkloadTypeAzureFileShare),
+		string(WorkloadTypeAzureSqlDb),
+		string(WorkloadTypeClient),
+		string(WorkloadTypeExchange),
+		string(WorkloadTypeFileFolder),
+		string(WorkloadTypeGenericDataSource),
+		string(WorkloadTypeInvalid),
+		string(WorkloadTypeSAPAseDatabase),
+		string(WorkloadTypeSAPHanaDBInstance),
+		string(WorkloadTypeSAPHanaDatabase),
+		string(WorkloadTypeSQLDB),
+		string(WorkloadTypeSQLDataBase),
+		string(WorkloadTypeSharepoint),
+		string(WorkloadTypeSystemState),
+		string(WorkloadTypeVM),
+		string(WorkloadTypeVMwareVM),
+	}
+}
+
+func parseWorkloadType(input string) (*WorkloadType, error) {
+	vals := map[string]WorkloadType{
+		"azurefileshare":    WorkloadTypeAzureFileShare,
+		"azuresqldb":        WorkloadTypeAzureSqlDb,
+		"client":            WorkloadTypeClient,
+		"exchange":          WorkloadTypeExchange,
+		"filefolder":        WorkloadTypeFileFolder,
+		"genericdatasource": WorkloadTypeGenericDataSource,
+		"invalid":           WorkloadTypeInvalid,
+		"sapasedatabase":    WorkloadTypeSAPAseDatabase,
+		"saphanadbinstance": WorkloadTypeSAPHanaDBInstance,
+		"saphanadatabase":   WorkloadTypeSAPHanaDatabase,
+		"sqldb":             WorkloadTypeSQLDB,
+		"sqldatabase":       WorkloadTypeSQLDataBase,
+		"sharepoint":        WorkloadTypeSharepoint,
+		"systemstate":       WorkloadTypeSystemState,
+		"vm":                WorkloadTypeVM,
+		"vmwarevm":          WorkloadTypeVMwareVM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkloadType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/id_vault.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/id_vault.go
@@ -1,0 +1,130 @@
+package backupprotectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&VaultId{})
+}
+
+var _ resourceids.ResourceId = &VaultId{}
+
+// VaultId is a struct representing the Resource ID for a Vault
+type VaultId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	VaultName         string
+}
+
+// NewVaultID returns a new VaultId struct
+func NewVaultID(subscriptionId string, resourceGroupName string, vaultName string) VaultId {
+	return VaultId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VaultName:         vaultName,
+	}
+}
+
+// ParseVaultID parses 'input' into a VaultId
+func ParseVaultID(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VaultId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VaultId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseVaultIDInsensitively parses 'input' case-insensitively into a VaultId
+// note: this method should only be used for API response data and not user input
+func ParseVaultIDInsensitively(input string) (*VaultId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&VaultId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := VaultId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *VaultId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VaultName, ok = input.Parsed["vaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "vaultName", input)
+	}
+
+	return nil
+}
+
+// ValidateVaultID checks that 'input' can be parsed as a Vault ID
+func ValidateVaultID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseVaultID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Vault ID
+func (id VaultId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Vault ID
+func (id VaultId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultName"),
+	}
+}
+
+// String returns a human-readable description of this Vault ID
+func (id VaultId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+	}
+	return fmt.Sprintf("Vault (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/method_list_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/method_list_autorest.go
@@ -1,0 +1,215 @@
+package backupprotectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ListOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *[]ProtectionContainerResource
+
+	nextLink     *string
+	nextPageFunc func(ctx context.Context, nextLink string) (ListOperationResponse, error)
+}
+
+type ListCompleteResult struct {
+	Items []ProtectionContainerResource
+}
+
+func (r ListOperationResponse) HasMore() bool {
+	return r.nextLink != nil
+}
+
+func (r ListOperationResponse) LoadMore(ctx context.Context) (resp ListOperationResponse, err error) {
+	if !r.HasMore() {
+		err = fmt.Errorf("no more pages returned")
+		return
+	}
+	return r.nextPageFunc(ctx, *r.nextLink)
+}
+
+type ListOperationOptions struct {
+	Filter *string
+}
+
+func DefaultListOperationOptions() ListOperationOptions {
+	return ListOperationOptions{}
+}
+
+func (o ListOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o ListOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	return out
+}
+
+// List ...
+func (c BackupProtectionContainersClient) List(ctx context.Context, id VaultId, options ListOperationOptions) (resp ListOperationResponse, err error) {
+	req, err := c.preparerForList(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", nil, "Failure preparing request")
+		return
+	}
+
+	resp.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", resp.HttpResponse, "Failure sending request")
+		return
+	}
+
+	resp, err = c.responderForList(resp.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", resp.HttpResponse, "Failure responding to request")
+		return
+	}
+	return
+}
+
+// preparerForList prepares the List request.
+func (c BackupProtectionContainersClient) preparerForList(ctx context.Context, id VaultId, options ListOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/backupProtectionContainers", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// preparerForListWithNextLink prepares the List request with the given nextLink token.
+func (c BackupProtectionContainersClient) preparerForListWithNextLink(ctx context.Context, nextLink string) (*http.Request, error) {
+	uri, err := url.Parse(nextLink)
+	if err != nil {
+		return nil, fmt.Errorf("parsing nextLink %q: %+v", nextLink, err)
+	}
+	queryParameters := map[string]interface{}{}
+	for k, v := range uri.Query() {
+		if len(v) == 0 {
+			continue
+		}
+		val := v[0]
+		val = autorest.Encode("query", val)
+		queryParameters[k] = val
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(uri.Path),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForList handles the response to the List request. The method always
+// closes the http.Response Body.
+func (c BackupProtectionContainersClient) responderForList(resp *http.Response) (result ListOperationResponse, err error) {
+	type page struct {
+		Values   []ProtectionContainerResource `json:"value"`
+		NextLink *string                       `json:"nextLink"`
+	}
+	var respObj page
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&respObj),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+	result.Model = &respObj.Values
+	result.nextLink = respObj.NextLink
+	if respObj.NextLink != nil {
+		result.nextPageFunc = func(ctx context.Context, nextLink string) (result ListOperationResponse, err error) {
+			req, err := c.preparerForListWithNextLink(ctx, nextLink)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", nil, "Failure preparing request")
+				return
+			}
+
+			result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", result.HttpResponse, "Failure sending request")
+				return
+			}
+
+			result, err = c.responderForList(result.HttpResponse)
+			if err != nil {
+				err = autorest.NewErrorWithError(err, "backupprotectioncontainers.BackupProtectionContainersClient", "List", result.HttpResponse, "Failure responding to request")
+				return
+			}
+
+			return
+		}
+	}
+	return
+}
+
+// ListComplete retrieves all of the results into a single object
+func (c BackupProtectionContainersClient) ListComplete(ctx context.Context, id VaultId, options ListOperationOptions) (ListCompleteResult, error) {
+	return c.ListCompleteMatchingPredicate(ctx, id, options, ProtectionContainerResourceOperationPredicate{})
+}
+
+// ListCompleteMatchingPredicate retrieves all of the results and then applied the predicate
+func (c BackupProtectionContainersClient) ListCompleteMatchingPredicate(ctx context.Context, id VaultId, options ListOperationOptions, predicate ProtectionContainerResourceOperationPredicate) (resp ListCompleteResult, err error) {
+	items := make([]ProtectionContainerResource, 0)
+
+	page, err := c.List(ctx, id, options)
+	if err != nil {
+		err = fmt.Errorf("loading the initial page: %+v", err)
+		return
+	}
+	if page.Model != nil {
+		for _, v := range *page.Model {
+			if predicate.Matches(v) {
+				items = append(items, v)
+			}
+		}
+	}
+
+	for page.HasMore() {
+		page, err = page.LoadMore(ctx)
+		if err != nil {
+			err = fmt.Errorf("loading the next page: %+v", err)
+			return
+		}
+
+		if page.Model != nil {
+			for _, v := range *page.Model {
+				if predicate.Matches(v) {
+					items = append(items, v)
+				}
+			}
+		}
+	}
+
+	out := ListCompleteResult{
+		Items: items,
+	}
+	return out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurebackupservercontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurebackupservercontainer.go
@@ -1,0 +1,67 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureBackupServerContainer{}
+
+type AzureBackupServerContainer struct {
+	CanReRegister      *bool                     `json:"canReRegister,omitempty"`
+	ContainerId        *string                   `json:"containerId,omitempty"`
+	DpmAgentVersion    *string                   `json:"dpmAgentVersion,omitempty"`
+	DpmServers         *[]string                 `json:"dpmServers,omitempty"`
+	ExtendedInfo       *DPMContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	ProtectedItemCount *int64                    `json:"protectedItemCount,omitempty"`
+	ProtectionStatus   *string                   `json:"protectionStatus,omitempty"`
+	UpgradeAvailable   *bool                     `json:"upgradeAvailable,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureBackupServerContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureBackupServerContainer{}
+
+func (s AzureBackupServerContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureBackupServerContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureBackupServerContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureiaasclassiccomputevmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureiaasclassiccomputevmcontainer.go
@@ -1,0 +1,62 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureIaaSClassicComputeVMContainer{}
+
+type AzureIaaSClassicComputeVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureIaaSClassicComputeVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureIaaSClassicComputeVMContainer{}
+
+func (s AzureIaaSClassicComputeVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureIaaSClassicComputeVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Microsoft.ClassicCompute/virtualMachines"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureiaascomputevmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureiaascomputevmcontainer.go
@@ -1,0 +1,62 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureIaaSComputeVMContainer{}
+
+type AzureIaaSComputeVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureIaaSComputeVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureIaaSComputeVMContainer{}
+
+func (s AzureIaaSComputeVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureIaaSComputeVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Microsoft.Compute/virtualMachines"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azuresqlagworkloadcontainerprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azuresqlagworkloadcontainerprotectioncontainer.go
@@ -1,0 +1,64 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureSQLAGWorkloadContainerProtectionContainer{}
+
+type AzureSQLAGWorkloadContainerProtectionContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureSQLAGWorkloadContainerProtectionContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureSQLAGWorkloadContainerProtectionContainer{}
+
+func (s AzureSQLAGWorkloadContainerProtectionContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureSQLAGWorkloadContainerProtectionContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "SQLAGWorkLoadContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azuresqlcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azuresqlcontainer.go
@@ -1,0 +1,59 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureSqlContainer{}
+
+type AzureSqlContainer struct {
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureSqlContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureSqlContainer{}
+
+func (s AzureSqlContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureSqlContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureSqlContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureSqlContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureSqlContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureSqlContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurestoragecontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurestoragecontainer.go
@@ -1,0 +1,65 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureStorageContainer{}
+
+type AzureStorageContainer struct {
+	AcquireStorageAccountLock *AcquireStorageAccountLock `json:"acquireStorageAccountLock,omitempty"`
+	OperationType             *OperationType             `json:"operationType,omitempty"`
+	ProtectedItemCount        *int64                     `json:"protectedItemCount,omitempty"`
+	ResourceGroup             *string                    `json:"resourceGroup,omitempty"`
+	SourceResourceId          *string                    `json:"sourceResourceId,omitempty"`
+	StorageAccountVersion     *string                    `json:"storageAccountVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureStorageContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureStorageContainer{}
+
+func (s AzureStorageContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureStorageContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureStorageContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureStorageContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "StorageContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureStorageContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurevmappcontainerprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azurevmappcontainerprotectioncontainer.go
@@ -1,0 +1,64 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureVMAppContainerProtectionContainer{}
+
+type AzureVMAppContainerProtectionContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureVMAppContainerProtectionContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureVMAppContainerProtectionContainer{}
+
+func (s AzureVMAppContainerProtectionContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureVMAppContainerProtectionContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "VMAppContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureworkloadcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureworkloadcontainer.go
@@ -1,0 +1,64 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureWorkloadContainer{}
+
+type AzureWorkloadContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureWorkloadContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureWorkloadContainer{}
+
+func (s AzureWorkloadContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureWorkloadContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureWorkloadContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureworkloadcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_azureworkloadcontainerextendedinfo.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureWorkloadContainerExtendedInfo struct {
+	HostServerName *string                 `json:"hostServerName,omitempty"`
+	InquiryInfo    *InquiryInfo            `json:"inquiryInfo,omitempty"`
+	NodesList      *[]DistributedNodesInfo `json:"nodesList,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_containeridentityinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_containeridentityinfo.go
@@ -1,0 +1,11 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ContainerIdentityInfo struct {
+	AadTenantId              *string `json:"aadTenantId,omitempty"`
+	Audience                 *string `json:"audience,omitempty"`
+	ServicePrincipalClientId *string `json:"servicePrincipalClientId,omitempty"`
+	UniqueName               *string `json:"uniqueName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_distributednodesinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_distributednodesinfo.go
@@ -1,0 +1,11 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DistributedNodesInfo struct {
+	ErrorDetail      *ErrorDetail `json:"errorDetail,omitempty"`
+	NodeName         *string      `json:"nodeName,omitempty"`
+	SourceResourceId *string      `json:"sourceResourceId,omitempty"`
+	Status           *string      `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_dpmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_dpmcontainer.go
@@ -1,0 +1,67 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = DpmContainer{}
+
+type DpmContainer struct {
+	CanReRegister      *bool                     `json:"canReRegister,omitempty"`
+	ContainerId        *string                   `json:"containerId,omitempty"`
+	DpmAgentVersion    *string                   `json:"dpmAgentVersion,omitempty"`
+	DpmServers         *[]string                 `json:"dpmServers,omitempty"`
+	ExtendedInfo       *DPMContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	ProtectedItemCount *int64                    `json:"protectedItemCount,omitempty"`
+	ProtectionStatus   *string                   `json:"protectionStatus,omitempty"`
+	UpgradeAvailable   *bool                     `json:"upgradeAvailable,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s DpmContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = DpmContainer{}
+
+func (s DpmContainer) MarshalJSON() ([]byte, error) {
+	type wrapper DpmContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DpmContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DpmContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "DPMContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DpmContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_dpmcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_dpmcontainerextendedinfo.go
@@ -1,0 +1,26 @@
+package backupprotectioncontainers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DPMContainerExtendedInfo struct {
+	LastRefreshedAt *string `json:"lastRefreshedAt,omitempty"`
+}
+
+func (o *DPMContainerExtendedInfo) GetLastRefreshedAtAsTime() (*time.Time, error) {
+	if o.LastRefreshedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRefreshedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DPMContainerExtendedInfo) SetLastRefreshedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRefreshedAt = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_errordetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_errordetail.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorDetail struct {
+	Code            *string   `json:"code,omitempty"`
+	Message         *string   `json:"message,omitempty"`
+	Recommendations *[]string `json:"recommendations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_genericcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_genericcontainer.go
@@ -1,0 +1,61 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = GenericContainer{}
+
+type GenericContainer struct {
+	ExtendedInformation *GenericContainerExtendedInfo `json:"extendedInformation,omitempty"`
+	FabricName          *string                       `json:"fabricName,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s GenericContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = GenericContainer{}
+
+func (s GenericContainer) MarshalJSON() ([]byte, error) {
+	type wrapper GenericContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling GenericContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling GenericContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "GenericContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling GenericContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_genericcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_genericcontainerextendedinfo.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericContainerExtendedInfo struct {
+	ContainerIdentityInfo *ContainerIdentityInfo `json:"containerIdentityInfo,omitempty"`
+	RawCertData           *string                `json:"rawCertData,omitempty"`
+	ServiceEndpoints      *map[string]string     `json:"serviceEndpoints,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_iaasvmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_iaasvmcontainer.go
@@ -1,0 +1,62 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = IaaSVMContainer{}
+
+type IaaSVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s IaaSVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = IaaSVMContainer{}
+
+func (s IaaSVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper IaaSVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling IaaSVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling IaaSVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "IaasVMContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling IaaSVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_inquiryinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_inquiryinfo.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InquiryInfo struct {
+	ErrorDetail    *ErrorDetail              `json:"errorDetail,omitempty"`
+	InquiryDetails *[]WorkloadInquiryDetails `json:"inquiryDetails,omitempty"`
+	Status         *string                   `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_inquiryvalidation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_inquiryvalidation.go
@@ -1,0 +1,11 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InquiryValidation struct {
+	AdditionalDetail     *string      `json:"additionalDetail,omitempty"`
+	ErrorDetail          *ErrorDetail `json:"errorDetail,omitempty"`
+	ProtectableItemCount *interface{} `json:"protectableItemCount,omitempty"`
+	Status               *string      `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainer.go
@@ -1,0 +1,66 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = MabContainer{}
+
+type MabContainer struct {
+	AgentVersion              *string                      `json:"agentVersion,omitempty"`
+	CanReRegister             *bool                        `json:"canReRegister,omitempty"`
+	ContainerHealthState      *string                      `json:"containerHealthState,omitempty"`
+	ContainerId               *int64                       `json:"containerId,omitempty"`
+	ExtendedInfo              *MabContainerExtendedInfo    `json:"extendedInfo,omitempty"`
+	MabContainerHealthDetails *[]MABContainerHealthDetails `json:"mabContainerHealthDetails,omitempty"`
+	ProtectedItemCount        *int64                       `json:"protectedItemCount,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s MabContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = MabContainer{}
+
+func (s MabContainer) MarshalJSON() ([]byte, error) {
+	type wrapper MabContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling MabContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling MabContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Windows"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling MabContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainerextendedinfo.go
@@ -1,0 +1,30 @@
+package backupprotectioncontainers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MabContainerExtendedInfo struct {
+	BackupItemType   *BackupItemType `json:"backupItemType,omitempty"`
+	BackupItems      *[]string       `json:"backupItems,omitempty"`
+	LastBackupStatus *string         `json:"lastBackupStatus,omitempty"`
+	LastRefreshedAt  *string         `json:"lastRefreshedAt,omitempty"`
+	PolicyName       *string         `json:"policyName,omitempty"`
+}
+
+func (o *MabContainerExtendedInfo) GetLastRefreshedAtAsTime() (*time.Time, error) {
+	if o.LastRefreshedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRefreshedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MabContainerExtendedInfo) SetLastRefreshedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRefreshedAt = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainerhealthdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_mabcontainerhealthdetails.go
@@ -1,0 +1,11 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MABContainerHealthDetails struct {
+	Code            *int64    `json:"code,omitempty"`
+	Message         *string   `json:"message,omitempty"`
+	Recommendations *[]string `json:"recommendations,omitempty"`
+	Title           *string   `json:"title,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_protectioncontainer.go
@@ -1,0 +1,168 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainer interface {
+	ProtectionContainer() BaseProtectionContainerImpl
+}
+
+var _ ProtectionContainer = BaseProtectionContainerImpl{}
+
+type BaseProtectionContainerImpl struct {
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s BaseProtectionContainerImpl) ProtectionContainer() BaseProtectionContainerImpl {
+	return s
+}
+
+var _ ProtectionContainer = RawProtectionContainerImpl{}
+
+// RawProtectionContainerImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectionContainerImpl struct {
+	protectionContainer BaseProtectionContainerImpl
+	Type                string
+	Values              map[string]interface{}
+}
+
+func (s RawProtectionContainerImpl) ProtectionContainer() BaseProtectionContainerImpl {
+	return s.protectionContainer
+}
+
+func UnmarshalProtectionContainerImplementation(input []byte) (ProtectionContainer, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ProtectionContainer into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["containerType"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "AzureBackupServerContainer") {
+		var out AzureBackupServerContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureBackupServerContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Microsoft.ClassicCompute/virtualMachines") {
+		var out AzureIaaSClassicComputeVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureIaaSClassicComputeVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Microsoft.Compute/virtualMachines") {
+		var out AzureIaaSComputeVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureIaaSComputeVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SQLAGWorkLoadContainer") {
+		var out AzureSQLAGWorkloadContainerProtectionContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureSqlContainer") {
+		var out AzureSqlContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureSqlContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "StorageContainer") {
+		var out AzureStorageContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureStorageContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMAppContainer") {
+		var out AzureVMAppContainerProtectionContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureVMAppContainerProtectionContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureWorkloadContainer") {
+		var out AzureWorkloadContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureWorkloadContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DPMContainer") {
+		var out DpmContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DpmContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "GenericContainer") {
+		var out GenericContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into GenericContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "IaasVMContainer") {
+		var out IaaSVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into IaaSVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Windows") {
+		var out MabContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into MabContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseProtectionContainerImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseProtectionContainerImpl: %+v", err)
+	}
+
+	return RawProtectionContainerImpl{
+		protectionContainer: parent,
+		Type:                value,
+		Values:              temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_protectioncontainerresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_protectioncontainerresource.go
@@ -1,0 +1,57 @@
+package backupprotectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerResource struct {
+	ETag       *string             `json:"eTag,omitempty"`
+	Id         *string             `json:"id,omitempty"`
+	Location   *string             `json:"location,omitempty"`
+	Name       *string             `json:"name,omitempty"`
+	Properties ProtectionContainer `json:"properties"`
+	Tags       *map[string]string  `json:"tags,omitempty"`
+	Type       *string             `json:"type,omitempty"`
+}
+
+var _ json.Unmarshaler = &ProtectionContainerResource{}
+
+func (s *ProtectionContainerResource) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		ETag     *string            `json:"eTag,omitempty"`
+		Id       *string            `json:"id,omitempty"`
+		Location *string            `json:"location,omitempty"`
+		Name     *string            `json:"name,omitempty"`
+		Tags     *map[string]string `json:"tags,omitempty"`
+		Type     *string            `json:"type,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.ETag = decoded.ETag
+	s.Id = decoded.Id
+	s.Location = decoded.Location
+	s.Name = decoded.Name
+	s.Tags = decoded.Tags
+	s.Type = decoded.Type
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ProtectionContainerResource into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["properties"]; ok {
+		impl, err := UnmarshalProtectionContainerImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Properties' for 'ProtectionContainerResource': %+v", err)
+		}
+		s.Properties = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_workloadinquirydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/model_workloadinquirydetails.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkloadInquiryDetails struct {
+	InquiryValidation *InquiryValidation `json:"inquiryValidation,omitempty"`
+	ItemCount         *int64             `json:"itemCount,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/predicates.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/predicates.go
@@ -1,0 +1,37 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerResourceOperationPredicate struct {
+	ETag     *string
+	Id       *string
+	Location *string
+	Name     *string
+	Type     *string
+}
+
+func (p ProtectionContainerResourceOperationPredicate) Matches(input ProtectionContainerResource) bool {
+
+	if p.ETag != nil && (input.ETag == nil || *p.ETag != *input.ETag) {
+		return false
+	}
+
+	if p.Id != nil && (input.Id == nil || *p.Id != *input.Id) {
+		return false
+	}
+
+	if p.Location != nil && (input.Location == nil || *p.Location != *input.Location) {
+		return false
+	}
+
+	if p.Name != nil && (input.Name == nil || *p.Name != *input.Name) {
+		return false
+	}
+
+	if p.Type != nil && (input.Type == nil || *p.Type != *input.Type) {
+		return false
+	}
+
+	return true
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers/version.go
@@ -1,0 +1,10 @@
+package backupprotectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-10-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/backupprotectioncontainers/2024-10-01"
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/README.md
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/README.md
@@ -1,0 +1,101 @@
+
+## `github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers` Documentation
+
+The `protectioncontainers` SDK allows for interaction with Azure Resource Manager `recoveryservicesbackup` (API Version `2024-10-01`).
+
+This readme covers example usages, but further information on [using this SDK can be found in the project root](https://github.com/hashicorp/go-azure-sdk/tree/main/docs).
+
+### Import Path
+
+```go
+import "github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers"
+```
+
+
+### Client Initialization
+
+```go
+client := protectioncontainers.NewProtectionContainersClientWithBaseURI("https://management.azure.com")
+client.Client.Authorizer = authorizer
+```
+
+
+### Example Usage: `ProtectionContainersClient.Get`
+
+```go
+ctx := context.TODO()
+id := protectioncontainers.NewProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName", "protectionContainerName")
+
+read, err := client.Get(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ProtectionContainersClient.Inquire`
+
+```go
+ctx := context.TODO()
+id := protectioncontainers.NewProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName", "protectionContainerName")
+
+read, err := client.Inquire(ctx, id, protectioncontainers.DefaultInquireOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ProtectionContainersClient.Refresh`
+
+```go
+ctx := context.TODO()
+id := protectioncontainers.NewBackupFabricID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName")
+
+read, err := client.Refresh(ctx, id, protectioncontainers.DefaultRefreshOperationOptions())
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```
+
+
+### Example Usage: `ProtectionContainersClient.Register`
+
+```go
+ctx := context.TODO()
+id := protectioncontainers.NewProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName", "protectionContainerName")
+
+payload := protectioncontainers.ProtectionContainerResource{
+	// ...
+}
+
+
+if err := client.RegisterThenPoll(ctx, id, payload); err != nil {
+	// handle the error
+}
+```
+
+
+### Example Usage: `ProtectionContainersClient.Unregister`
+
+```go
+ctx := context.TODO()
+id := protectioncontainers.NewProtectionContainerID("12345678-1234-9876-4563-123456789012", "example-resource-group", "vaultName", "backupFabricName", "protectionContainerName")
+
+read, err := client.Unregister(ctx, id)
+if err != nil {
+	// handle the error
+}
+if model := read.Model; model != nil {
+	// do something with the model/response object
+}
+```

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/client.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/client.go
@@ -1,0 +1,18 @@
+package protectioncontainers
+
+import "github.com/Azure/go-autorest/autorest"
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainersClient struct {
+	Client  autorest.Client
+	baseUri string
+}
+
+func NewProtectionContainersClientWithBaseURI(endpoint string) ProtectionContainersClient {
+	return ProtectionContainersClient{
+		Client:  autorest.NewClientWithUserAgent(userAgent()),
+		baseUri: endpoint,
+	}
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/constants.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/constants.go
@@ -1,0 +1,335 @@
+package protectioncontainers
+
+import (
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AcquireStorageAccountLock string
+
+const (
+	AcquireStorageAccountLockAcquire    AcquireStorageAccountLock = "Acquire"
+	AcquireStorageAccountLockNotAcquire AcquireStorageAccountLock = "NotAcquire"
+)
+
+func PossibleValuesForAcquireStorageAccountLock() []string {
+	return []string{
+		string(AcquireStorageAccountLockAcquire),
+		string(AcquireStorageAccountLockNotAcquire),
+	}
+}
+
+func parseAcquireStorageAccountLock(input string) (*AcquireStorageAccountLock, error) {
+	vals := map[string]AcquireStorageAccountLock{
+		"acquire":    AcquireStorageAccountLockAcquire,
+		"notacquire": AcquireStorageAccountLockNotAcquire,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := AcquireStorageAccountLock(input)
+	return &out, nil
+}
+
+type BackupItemType string
+
+const (
+	BackupItemTypeAzureFileShare    BackupItemType = "AzureFileShare"
+	BackupItemTypeAzureSqlDb        BackupItemType = "AzureSqlDb"
+	BackupItemTypeClient            BackupItemType = "Client"
+	BackupItemTypeExchange          BackupItemType = "Exchange"
+	BackupItemTypeFileFolder        BackupItemType = "FileFolder"
+	BackupItemTypeGenericDataSource BackupItemType = "GenericDataSource"
+	BackupItemTypeInvalid           BackupItemType = "Invalid"
+	BackupItemTypeSAPAseDatabase    BackupItemType = "SAPAseDatabase"
+	BackupItemTypeSAPHanaDBInstance BackupItemType = "SAPHanaDBInstance"
+	BackupItemTypeSAPHanaDatabase   BackupItemType = "SAPHanaDatabase"
+	BackupItemTypeSQLDB             BackupItemType = "SQLDB"
+	BackupItemTypeSQLDataBase       BackupItemType = "SQLDataBase"
+	BackupItemTypeSharepoint        BackupItemType = "Sharepoint"
+	BackupItemTypeSystemState       BackupItemType = "SystemState"
+	BackupItemTypeVM                BackupItemType = "VM"
+	BackupItemTypeVMwareVM          BackupItemType = "VMwareVM"
+)
+
+func PossibleValuesForBackupItemType() []string {
+	return []string{
+		string(BackupItemTypeAzureFileShare),
+		string(BackupItemTypeAzureSqlDb),
+		string(BackupItemTypeClient),
+		string(BackupItemTypeExchange),
+		string(BackupItemTypeFileFolder),
+		string(BackupItemTypeGenericDataSource),
+		string(BackupItemTypeInvalid),
+		string(BackupItemTypeSAPAseDatabase),
+		string(BackupItemTypeSAPHanaDBInstance),
+		string(BackupItemTypeSAPHanaDatabase),
+		string(BackupItemTypeSQLDB),
+		string(BackupItemTypeSQLDataBase),
+		string(BackupItemTypeSharepoint),
+		string(BackupItemTypeSystemState),
+		string(BackupItemTypeVM),
+		string(BackupItemTypeVMwareVM),
+	}
+}
+
+func parseBackupItemType(input string) (*BackupItemType, error) {
+	vals := map[string]BackupItemType{
+		"azurefileshare":    BackupItemTypeAzureFileShare,
+		"azuresqldb":        BackupItemTypeAzureSqlDb,
+		"client":            BackupItemTypeClient,
+		"exchange":          BackupItemTypeExchange,
+		"filefolder":        BackupItemTypeFileFolder,
+		"genericdatasource": BackupItemTypeGenericDataSource,
+		"invalid":           BackupItemTypeInvalid,
+		"sapasedatabase":    BackupItemTypeSAPAseDatabase,
+		"saphanadbinstance": BackupItemTypeSAPHanaDBInstance,
+		"saphanadatabase":   BackupItemTypeSAPHanaDatabase,
+		"sqldb":             BackupItemTypeSQLDB,
+		"sqldatabase":       BackupItemTypeSQLDataBase,
+		"sharepoint":        BackupItemTypeSharepoint,
+		"systemstate":       BackupItemTypeSystemState,
+		"vm":                BackupItemTypeVM,
+		"vmwarevm":          BackupItemTypeVMwareVM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := BackupItemType(input)
+	return &out, nil
+}
+
+type BackupManagementType string
+
+const (
+	BackupManagementTypeAzureBackupServer BackupManagementType = "AzureBackupServer"
+	BackupManagementTypeAzureIaasVM       BackupManagementType = "AzureIaasVM"
+	BackupManagementTypeAzureSql          BackupManagementType = "AzureSql"
+	BackupManagementTypeAzureStorage      BackupManagementType = "AzureStorage"
+	BackupManagementTypeAzureWorkload     BackupManagementType = "AzureWorkload"
+	BackupManagementTypeDPM               BackupManagementType = "DPM"
+	BackupManagementTypeDefaultBackup     BackupManagementType = "DefaultBackup"
+	BackupManagementTypeInvalid           BackupManagementType = "Invalid"
+	BackupManagementTypeMAB               BackupManagementType = "MAB"
+)
+
+func PossibleValuesForBackupManagementType() []string {
+	return []string{
+		string(BackupManagementTypeAzureBackupServer),
+		string(BackupManagementTypeAzureIaasVM),
+		string(BackupManagementTypeAzureSql),
+		string(BackupManagementTypeAzureStorage),
+		string(BackupManagementTypeAzureWorkload),
+		string(BackupManagementTypeDPM),
+		string(BackupManagementTypeDefaultBackup),
+		string(BackupManagementTypeInvalid),
+		string(BackupManagementTypeMAB),
+	}
+}
+
+func parseBackupManagementType(input string) (*BackupManagementType, error) {
+	vals := map[string]BackupManagementType{
+		"azurebackupserver": BackupManagementTypeAzureBackupServer,
+		"azureiaasvm":       BackupManagementTypeAzureIaasVM,
+		"azuresql":          BackupManagementTypeAzureSql,
+		"azurestorage":      BackupManagementTypeAzureStorage,
+		"azureworkload":     BackupManagementTypeAzureWorkload,
+		"dpm":               BackupManagementTypeDPM,
+		"defaultbackup":     BackupManagementTypeDefaultBackup,
+		"invalid":           BackupManagementTypeInvalid,
+		"mab":               BackupManagementTypeMAB,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := BackupManagementType(input)
+	return &out, nil
+}
+
+type OperationType string
+
+const (
+	OperationTypeInvalid    OperationType = "Invalid"
+	OperationTypeRegister   OperationType = "Register"
+	OperationTypeRehydrate  OperationType = "Rehydrate"
+	OperationTypeReregister OperationType = "Reregister"
+)
+
+func PossibleValuesForOperationType() []string {
+	return []string{
+		string(OperationTypeInvalid),
+		string(OperationTypeRegister),
+		string(OperationTypeRehydrate),
+		string(OperationTypeReregister),
+	}
+}
+
+func parseOperationType(input string) (*OperationType, error) {
+	vals := map[string]OperationType{
+		"invalid":    OperationTypeInvalid,
+		"register":   OperationTypeRegister,
+		"rehydrate":  OperationTypeRehydrate,
+		"reregister": OperationTypeReregister,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := OperationType(input)
+	return &out, nil
+}
+
+type ProtectableContainerType string
+
+const (
+	ProtectableContainerTypeAzureBackupServerContainer                  ProtectableContainerType = "AzureBackupServerContainer"
+	ProtectableContainerTypeAzureSqlContainer                           ProtectableContainerType = "AzureSqlContainer"
+	ProtectableContainerTypeAzureWorkloadContainer                      ProtectableContainerType = "AzureWorkloadContainer"
+	ProtectableContainerTypeCluster                                     ProtectableContainerType = "Cluster"
+	ProtectableContainerTypeDPMContainer                                ProtectableContainerType = "DPMContainer"
+	ProtectableContainerTypeGenericContainer                            ProtectableContainerType = "GenericContainer"
+	ProtectableContainerTypeIaasVMContainer                             ProtectableContainerType = "IaasVMContainer"
+	ProtectableContainerTypeIaasVMServiceContainer                      ProtectableContainerType = "IaasVMServiceContainer"
+	ProtectableContainerTypeInvalid                                     ProtectableContainerType = "Invalid"
+	ProtectableContainerTypeMABContainer                                ProtectableContainerType = "MABContainer"
+	ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines ProtectableContainerType = "Microsoft.ClassicCompute/virtualMachines"
+	ProtectableContainerTypeMicrosoftPointComputeVirtualMachines        ProtectableContainerType = "Microsoft.Compute/virtualMachines"
+	ProtectableContainerTypeSQLAGWorkLoadContainer                      ProtectableContainerType = "SQLAGWorkLoadContainer"
+	ProtectableContainerTypeStorageContainer                            ProtectableContainerType = "StorageContainer"
+	ProtectableContainerTypeUnknown                                     ProtectableContainerType = "Unknown"
+	ProtectableContainerTypeVCenter                                     ProtectableContainerType = "VCenter"
+	ProtectableContainerTypeVMAppContainer                              ProtectableContainerType = "VMAppContainer"
+	ProtectableContainerTypeWindows                                     ProtectableContainerType = "Windows"
+)
+
+func PossibleValuesForProtectableContainerType() []string {
+	return []string{
+		string(ProtectableContainerTypeAzureBackupServerContainer),
+		string(ProtectableContainerTypeAzureSqlContainer),
+		string(ProtectableContainerTypeAzureWorkloadContainer),
+		string(ProtectableContainerTypeCluster),
+		string(ProtectableContainerTypeDPMContainer),
+		string(ProtectableContainerTypeGenericContainer),
+		string(ProtectableContainerTypeIaasVMContainer),
+		string(ProtectableContainerTypeIaasVMServiceContainer),
+		string(ProtectableContainerTypeInvalid),
+		string(ProtectableContainerTypeMABContainer),
+		string(ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines),
+		string(ProtectableContainerTypeMicrosoftPointComputeVirtualMachines),
+		string(ProtectableContainerTypeSQLAGWorkLoadContainer),
+		string(ProtectableContainerTypeStorageContainer),
+		string(ProtectableContainerTypeUnknown),
+		string(ProtectableContainerTypeVCenter),
+		string(ProtectableContainerTypeVMAppContainer),
+		string(ProtectableContainerTypeWindows),
+	}
+}
+
+func parseProtectableContainerType(input string) (*ProtectableContainerType, error) {
+	vals := map[string]ProtectableContainerType{
+		"azurebackupservercontainer": ProtectableContainerTypeAzureBackupServerContainer,
+		"azuresqlcontainer":          ProtectableContainerTypeAzureSqlContainer,
+		"azureworkloadcontainer":     ProtectableContainerTypeAzureWorkloadContainer,
+		"cluster":                    ProtectableContainerTypeCluster,
+		"dpmcontainer":               ProtectableContainerTypeDPMContainer,
+		"genericcontainer":           ProtectableContainerTypeGenericContainer,
+		"iaasvmcontainer":            ProtectableContainerTypeIaasVMContainer,
+		"iaasvmservicecontainer":     ProtectableContainerTypeIaasVMServiceContainer,
+		"invalid":                    ProtectableContainerTypeInvalid,
+		"mabcontainer":               ProtectableContainerTypeMABContainer,
+		"microsoft.classiccompute/virtualmachines": ProtectableContainerTypeMicrosoftPointClassicComputeVirtualMachines,
+		"microsoft.compute/virtualmachines":        ProtectableContainerTypeMicrosoftPointComputeVirtualMachines,
+		"sqlagworkloadcontainer":                   ProtectableContainerTypeSQLAGWorkLoadContainer,
+		"storagecontainer":                         ProtectableContainerTypeStorageContainer,
+		"unknown":                                  ProtectableContainerTypeUnknown,
+		"vcenter":                                  ProtectableContainerTypeVCenter,
+		"vmappcontainer":                           ProtectableContainerTypeVMAppContainer,
+		"windows":                                  ProtectableContainerTypeWindows,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := ProtectableContainerType(input)
+	return &out, nil
+}
+
+type WorkloadType string
+
+const (
+	WorkloadTypeAzureFileShare    WorkloadType = "AzureFileShare"
+	WorkloadTypeAzureSqlDb        WorkloadType = "AzureSqlDb"
+	WorkloadTypeClient            WorkloadType = "Client"
+	WorkloadTypeExchange          WorkloadType = "Exchange"
+	WorkloadTypeFileFolder        WorkloadType = "FileFolder"
+	WorkloadTypeGenericDataSource WorkloadType = "GenericDataSource"
+	WorkloadTypeInvalid           WorkloadType = "Invalid"
+	WorkloadTypeSAPAseDatabase    WorkloadType = "SAPAseDatabase"
+	WorkloadTypeSAPHanaDBInstance WorkloadType = "SAPHanaDBInstance"
+	WorkloadTypeSAPHanaDatabase   WorkloadType = "SAPHanaDatabase"
+	WorkloadTypeSQLDB             WorkloadType = "SQLDB"
+	WorkloadTypeSQLDataBase       WorkloadType = "SQLDataBase"
+	WorkloadTypeSharepoint        WorkloadType = "Sharepoint"
+	WorkloadTypeSystemState       WorkloadType = "SystemState"
+	WorkloadTypeVM                WorkloadType = "VM"
+	WorkloadTypeVMwareVM          WorkloadType = "VMwareVM"
+)
+
+func PossibleValuesForWorkloadType() []string {
+	return []string{
+		string(WorkloadTypeAzureFileShare),
+		string(WorkloadTypeAzureSqlDb),
+		string(WorkloadTypeClient),
+		string(WorkloadTypeExchange),
+		string(WorkloadTypeFileFolder),
+		string(WorkloadTypeGenericDataSource),
+		string(WorkloadTypeInvalid),
+		string(WorkloadTypeSAPAseDatabase),
+		string(WorkloadTypeSAPHanaDBInstance),
+		string(WorkloadTypeSAPHanaDatabase),
+		string(WorkloadTypeSQLDB),
+		string(WorkloadTypeSQLDataBase),
+		string(WorkloadTypeSharepoint),
+		string(WorkloadTypeSystemState),
+		string(WorkloadTypeVM),
+		string(WorkloadTypeVMwareVM),
+	}
+}
+
+func parseWorkloadType(input string) (*WorkloadType, error) {
+	vals := map[string]WorkloadType{
+		"azurefileshare":    WorkloadTypeAzureFileShare,
+		"azuresqldb":        WorkloadTypeAzureSqlDb,
+		"client":            WorkloadTypeClient,
+		"exchange":          WorkloadTypeExchange,
+		"filefolder":        WorkloadTypeFileFolder,
+		"genericdatasource": WorkloadTypeGenericDataSource,
+		"invalid":           WorkloadTypeInvalid,
+		"sapasedatabase":    WorkloadTypeSAPAseDatabase,
+		"saphanadbinstance": WorkloadTypeSAPHanaDBInstance,
+		"saphanadatabase":   WorkloadTypeSAPHanaDatabase,
+		"sqldb":             WorkloadTypeSQLDB,
+		"sqldatabase":       WorkloadTypeSQLDataBase,
+		"sharepoint":        WorkloadTypeSharepoint,
+		"systemstate":       WorkloadTypeSystemState,
+		"vm":                WorkloadTypeVM,
+		"vmwarevm":          WorkloadTypeVMwareVM,
+	}
+	if v, ok := vals[strings.ToLower(input)]; ok {
+		return &v, nil
+	}
+
+	// otherwise presume it's an undefined value and best-effort it
+	out := WorkloadType(input)
+	return &out, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/id_backupfabric.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/id_backupfabric.go
@@ -1,0 +1,139 @@
+package protectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&BackupFabricId{})
+}
+
+var _ resourceids.ResourceId = &BackupFabricId{}
+
+// BackupFabricId is a struct representing the Resource ID for a Backup Fabric
+type BackupFabricId struct {
+	SubscriptionId    string
+	ResourceGroupName string
+	VaultName         string
+	BackupFabricName  string
+}
+
+// NewBackupFabricID returns a new BackupFabricId struct
+func NewBackupFabricID(subscriptionId string, resourceGroupName string, vaultName string, backupFabricName string) BackupFabricId {
+	return BackupFabricId{
+		SubscriptionId:    subscriptionId,
+		ResourceGroupName: resourceGroupName,
+		VaultName:         vaultName,
+		BackupFabricName:  backupFabricName,
+	}
+}
+
+// ParseBackupFabricID parses 'input' into a BackupFabricId
+func ParseBackupFabricID(input string) (*BackupFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&BackupFabricId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := BackupFabricId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseBackupFabricIDInsensitively parses 'input' case-insensitively into a BackupFabricId
+// note: this method should only be used for API response data and not user input
+func ParseBackupFabricIDInsensitively(input string) (*BackupFabricId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&BackupFabricId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := BackupFabricId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *BackupFabricId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VaultName, ok = input.Parsed["vaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "vaultName", input)
+	}
+
+	if id.BackupFabricName, ok = input.Parsed["backupFabricName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", input)
+	}
+
+	return nil
+}
+
+// ValidateBackupFabricID checks that 'input' can be parsed as a Backup Fabric ID
+func ValidateBackupFabricID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseBackupFabricID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Backup Fabric ID
+func (id BackupFabricId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/backupFabrics/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName, id.BackupFabricName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Backup Fabric ID
+func (id BackupFabricId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultName"),
+		resourceids.StaticSegment("staticBackupFabrics", "backupFabrics", "backupFabrics"),
+		resourceids.UserSpecifiedSegment("backupFabricName", "backupFabricName"),
+	}
+}
+
+// String returns a human-readable description of this Backup Fabric ID
+func (id BackupFabricId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+		fmt.Sprintf("Backup Fabric Name: %q", id.BackupFabricName),
+	}
+	return fmt.Sprintf("Backup Fabric (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/id_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/id_protectioncontainer.go
@@ -1,0 +1,148 @@
+package protectioncontainers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/recaser"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+func init() {
+	recaser.RegisterResourceId(&ProtectionContainerId{})
+}
+
+var _ resourceids.ResourceId = &ProtectionContainerId{}
+
+// ProtectionContainerId is a struct representing the Resource ID for a Protection Container
+type ProtectionContainerId struct {
+	SubscriptionId          string
+	ResourceGroupName       string
+	VaultName               string
+	BackupFabricName        string
+	ProtectionContainerName string
+}
+
+// NewProtectionContainerID returns a new ProtectionContainerId struct
+func NewProtectionContainerID(subscriptionId string, resourceGroupName string, vaultName string, backupFabricName string, protectionContainerName string) ProtectionContainerId {
+	return ProtectionContainerId{
+		SubscriptionId:          subscriptionId,
+		ResourceGroupName:       resourceGroupName,
+		VaultName:               vaultName,
+		BackupFabricName:        backupFabricName,
+		ProtectionContainerName: protectionContainerName,
+	}
+}
+
+// ParseProtectionContainerID parses 'input' into a ProtectionContainerId
+func ParseProtectionContainerID(input string) (*ProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProtectionContainerId{})
+	parsed, err := parser.Parse(input, false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProtectionContainerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+// ParseProtectionContainerIDInsensitively parses 'input' case-insensitively into a ProtectionContainerId
+// note: this method should only be used for API response data and not user input
+func ParseProtectionContainerIDInsensitively(input string) (*ProtectionContainerId, error) {
+	parser := resourceids.NewParserFromResourceIdType(&ProtectionContainerId{})
+	parsed, err := parser.Parse(input, true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q: %+v", input, err)
+	}
+
+	id := ProtectionContainerId{}
+	if err = id.FromParseResult(*parsed); err != nil {
+		return nil, err
+	}
+
+	return &id, nil
+}
+
+func (id *ProtectionContainerId) FromParseResult(input resourceids.ParseResult) error {
+	var ok bool
+
+	if id.SubscriptionId, ok = input.Parsed["subscriptionId"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "subscriptionId", input)
+	}
+
+	if id.ResourceGroupName, ok = input.Parsed["resourceGroupName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "resourceGroupName", input)
+	}
+
+	if id.VaultName, ok = input.Parsed["vaultName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "vaultName", input)
+	}
+
+	if id.BackupFabricName, ok = input.Parsed["backupFabricName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "backupFabricName", input)
+	}
+
+	if id.ProtectionContainerName, ok = input.Parsed["protectionContainerName"]; !ok {
+		return resourceids.NewSegmentNotSpecifiedError(id, "protectionContainerName", input)
+	}
+
+	return nil
+}
+
+// ValidateProtectionContainerID checks that 'input' can be parsed as a Protection Container ID
+func ValidateProtectionContainerID(input interface{}, key string) (warnings []string, errors []error) {
+	v, ok := input.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected %q to be a string", key))
+		return
+	}
+
+	if _, err := ParseProtectionContainerID(v); err != nil {
+		errors = append(errors, err)
+	}
+
+	return
+}
+
+// ID returns the formatted Protection Container ID
+func (id ProtectionContainerId) ID() string {
+	fmtString := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.RecoveryServices/vaults/%s/backupFabrics/%s/protectionContainers/%s"
+	return fmt.Sprintf(fmtString, id.SubscriptionId, id.ResourceGroupName, id.VaultName, id.BackupFabricName, id.ProtectionContainerName)
+}
+
+// Segments returns a slice of Resource ID Segments which comprise this Protection Container ID
+func (id ProtectionContainerId) Segments() []resourceids.Segment {
+	return []resourceids.Segment{
+		resourceids.StaticSegment("staticSubscriptions", "subscriptions", "subscriptions"),
+		resourceids.SubscriptionIdSegment("subscriptionId", "12345678-1234-9876-4563-123456789012"),
+		resourceids.StaticSegment("staticResourceGroups", "resourceGroups", "resourceGroups"),
+		resourceids.ResourceGroupSegment("resourceGroupName", "example-resource-group"),
+		resourceids.StaticSegment("staticProviders", "providers", "providers"),
+		resourceids.ResourceProviderSegment("staticMicrosoftRecoveryServices", "Microsoft.RecoveryServices", "Microsoft.RecoveryServices"),
+		resourceids.StaticSegment("staticVaults", "vaults", "vaults"),
+		resourceids.UserSpecifiedSegment("vaultName", "vaultName"),
+		resourceids.StaticSegment("staticBackupFabrics", "backupFabrics", "backupFabrics"),
+		resourceids.UserSpecifiedSegment("backupFabricName", "backupFabricName"),
+		resourceids.StaticSegment("staticProtectionContainers", "protectionContainers", "protectionContainers"),
+		resourceids.UserSpecifiedSegment("protectionContainerName", "protectionContainerName"),
+	}
+}
+
+// String returns a human-readable description of this Protection Container ID
+func (id ProtectionContainerId) String() string {
+	components := []string{
+		fmt.Sprintf("Subscription: %q", id.SubscriptionId),
+		fmt.Sprintf("Resource Group Name: %q", id.ResourceGroupName),
+		fmt.Sprintf("Vault Name: %q", id.VaultName),
+		fmt.Sprintf("Backup Fabric Name: %q", id.BackupFabricName),
+		fmt.Sprintf("Protection Container Name: %q", id.ProtectionContainerName),
+	}
+	return fmt.Sprintf("Protection Container (%s)", strings.Join(components, "\n"))
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_get_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_get_autorest.go
@@ -1,0 +1,68 @@
+package protectioncontainers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GetOperationResponse struct {
+	HttpResponse *http.Response
+	Model        *ProtectionContainerResource
+}
+
+// Get ...
+func (c ProtectionContainersClient) Get(ctx context.Context, id ProtectionContainerId) (result GetOperationResponse, err error) {
+	req, err := c.preparerForGet(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Get", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Get", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForGet(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Get", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForGet prepares the Get request.
+func (c ProtectionContainersClient) preparerForGet(ctx context.Context, id ProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsGet(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForGet handles the response to the Get request. The method always
+// closes the http.Response Body.
+func (c ProtectionContainersClient) responderForGet(resp *http.Response) (result GetOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusOK),
+		autorest.ByUnmarshallingJSON(&result.Model),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_inquire_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_inquire_autorest.go
@@ -1,0 +1,96 @@
+package protectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InquireOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+type InquireOperationOptions struct {
+	Filter *string
+}
+
+func DefaultInquireOperationOptions() InquireOperationOptions {
+	return InquireOperationOptions{}
+}
+
+func (o InquireOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o InquireOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	return out
+}
+
+// Inquire ...
+func (c ProtectionContainersClient) Inquire(ctx context.Context, id ProtectionContainerId, options InquireOperationOptions) (result InquireOperationResponse, err error) {
+	req, err := c.preparerForInquire(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Inquire", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Inquire", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForInquire(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Inquire", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForInquire prepares the Inquire request.
+func (c ProtectionContainersClient) preparerForInquire(ctx context.Context, id ProtectionContainerId, options InquireOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/inquire", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForInquire handles the response to the Inquire request. The method always
+// closes the http.Response Body.
+func (c ProtectionContainersClient) responderForInquire(resp *http.Response) (result InquireOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_refresh_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_refresh_autorest.go
@@ -1,0 +1,96 @@
+package protectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RefreshOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+type RefreshOperationOptions struct {
+	Filter *string
+}
+
+func DefaultRefreshOperationOptions() RefreshOperationOptions {
+	return RefreshOperationOptions{}
+}
+
+func (o RefreshOperationOptions) toHeaders() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	return out
+}
+
+func (o RefreshOperationOptions) toQueryString() map[string]interface{} {
+	out := make(map[string]interface{})
+
+	if o.Filter != nil {
+		out["$filter"] = *o.Filter
+	}
+
+	return out
+}
+
+// Refresh ...
+func (c ProtectionContainersClient) Refresh(ctx context.Context, id BackupFabricId, options RefreshOperationOptions) (result RefreshOperationResponse, err error) {
+	req, err := c.preparerForRefresh(ctx, id, options)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Refresh", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Refresh", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForRefresh(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Refresh", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForRefresh prepares the Refresh request.
+func (c ProtectionContainersClient) preparerForRefresh(ctx context.Context, id BackupFabricId, options RefreshOperationOptions) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	for k, v := range options.toQueryString() {
+		queryParameters[k] = autorest.Encode("query", v)
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPost(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithHeaders(options.toHeaders()),
+		autorest.WithPath(fmt.Sprintf("%s/refreshContainers", id.ID())),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForRefresh handles the response to the Refresh request. The method always
+// closes the http.Response Body.
+func (c ProtectionContainersClient) responderForRefresh(resp *http.Response) (result RefreshOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_register_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_register_autorest.go
@@ -1,0 +1,80 @@
+package protectioncontainers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/hashicorp/go-azure-helpers/polling"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type RegisterOperationResponse struct {
+	Poller       polling.LongRunningPoller
+	HttpResponse *http.Response
+	Model        *ProtectionContainerResource
+}
+
+// Register ...
+func (c ProtectionContainersClient) Register(ctx context.Context, id ProtectionContainerId, input ProtectionContainerResource) (result RegisterOperationResponse, err error) {
+	req, err := c.preparerForRegister(ctx, id, input)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Register", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = c.senderForRegister(ctx, req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Register", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// RegisterThenPoll performs Register then polls until it's completed
+func (c ProtectionContainersClient) RegisterThenPoll(ctx context.Context, id ProtectionContainerId, input ProtectionContainerResource) error {
+	result, err := c.Register(ctx, id, input)
+	if err != nil {
+		return fmt.Errorf("performing Register: %+v", err)
+	}
+
+	if err := result.Poller.PollUntilDone(); err != nil {
+		return fmt.Errorf("polling after Register: %+v", err)
+	}
+
+	return nil
+}
+
+// preparerForRegister prepares the Register request.
+func (c ProtectionContainersClient) preparerForRegister(ctx context.Context, id ProtectionContainerId, input ProtectionContainerResource) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithJSON(input),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// senderForRegister sends the Register request. The method will close the
+// http.Response Body if it receives an error.
+func (c ProtectionContainersClient) senderForRegister(ctx context.Context, req *http.Request) (future RegisterOperationResponse, err error) {
+	var resp *http.Response
+	resp, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		return
+	}
+
+	future.Poller, err = polling.NewPollerFromResponse(ctx, resp, c.Client, req.Method)
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_unregister_autorest.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/method_unregister_autorest.go
@@ -1,0 +1,66 @@
+package protectioncontainers
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type UnregisterOperationResponse struct {
+	HttpResponse *http.Response
+}
+
+// Unregister ...
+func (c ProtectionContainersClient) Unregister(ctx context.Context, id ProtectionContainerId) (result UnregisterOperationResponse, err error) {
+	req, err := c.preparerForUnregister(ctx, id)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Unregister", nil, "Failure preparing request")
+		return
+	}
+
+	result.HttpResponse, err = c.Client.Send(req, azure.DoRetryWithRegistration(c.Client))
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Unregister", result.HttpResponse, "Failure sending request")
+		return
+	}
+
+	result, err = c.responderForUnregister(result.HttpResponse)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "protectioncontainers.ProtectionContainersClient", "Unregister", result.HttpResponse, "Failure responding to request")
+		return
+	}
+
+	return
+}
+
+// preparerForUnregister prepares the Unregister request.
+func (c ProtectionContainersClient) preparerForUnregister(ctx context.Context, id ProtectionContainerId) (*http.Request, error) {
+	queryParameters := map[string]interface{}{
+		"api-version": defaultApiVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsDelete(),
+		autorest.WithBaseURL(c.baseUri),
+		autorest.WithPath(id.ID()),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// responderForUnregister handles the response to the Unregister request. The method always
+// closes the http.Response Body.
+func (c ProtectionContainersClient) responderForUnregister(resp *http.Response) (result UnregisterOperationResponse, err error) {
+	err = autorest.Respond(
+		resp,
+		azure.WithErrorUnlessStatusCode(http.StatusAccepted, http.StatusNoContent, http.StatusOK),
+		autorest.ByClosing())
+	result.HttpResponse = resp
+
+	return
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurebackupservercontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurebackupservercontainer.go
@@ -1,0 +1,67 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureBackupServerContainer{}
+
+type AzureBackupServerContainer struct {
+	CanReRegister      *bool                     `json:"canReRegister,omitempty"`
+	ContainerId        *string                   `json:"containerId,omitempty"`
+	DpmAgentVersion    *string                   `json:"dpmAgentVersion,omitempty"`
+	DpmServers         *[]string                 `json:"dpmServers,omitempty"`
+	ExtendedInfo       *DPMContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	ProtectedItemCount *int64                    `json:"protectedItemCount,omitempty"`
+	ProtectionStatus   *string                   `json:"protectionStatus,omitempty"`
+	UpgradeAvailable   *bool                     `json:"upgradeAvailable,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureBackupServerContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureBackupServerContainer{}
+
+func (s AzureBackupServerContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureBackupServerContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureBackupServerContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureBackupServerContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureiaasclassiccomputevmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureiaasclassiccomputevmcontainer.go
@@ -1,0 +1,62 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureIaaSClassicComputeVMContainer{}
+
+type AzureIaaSClassicComputeVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureIaaSClassicComputeVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureIaaSClassicComputeVMContainer{}
+
+func (s AzureIaaSClassicComputeVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureIaaSClassicComputeVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Microsoft.ClassicCompute/virtualMachines"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureIaaSClassicComputeVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureiaascomputevmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureiaascomputevmcontainer.go
@@ -1,0 +1,62 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureIaaSComputeVMContainer{}
+
+type AzureIaaSComputeVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureIaaSComputeVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureIaaSComputeVMContainer{}
+
+func (s AzureIaaSComputeVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureIaaSComputeVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Microsoft.Compute/virtualMachines"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureIaaSComputeVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azuresqlagworkloadcontainerprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azuresqlagworkloadcontainerprotectioncontainer.go
@@ -1,0 +1,64 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureSQLAGWorkloadContainerProtectionContainer{}
+
+type AzureSQLAGWorkloadContainerProtectionContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureSQLAGWorkloadContainerProtectionContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureSQLAGWorkloadContainerProtectionContainer{}
+
+func (s AzureSQLAGWorkloadContainerProtectionContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureSQLAGWorkloadContainerProtectionContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "SQLAGWorkLoadContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azuresqlcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azuresqlcontainer.go
@@ -1,0 +1,59 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureSqlContainer{}
+
+type AzureSqlContainer struct {
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureSqlContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureSqlContainer{}
+
+func (s AzureSqlContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureSqlContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureSqlContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureSqlContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureSqlContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureSqlContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurestoragecontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurestoragecontainer.go
@@ -1,0 +1,65 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureStorageContainer{}
+
+type AzureStorageContainer struct {
+	AcquireStorageAccountLock *AcquireStorageAccountLock `json:"acquireStorageAccountLock,omitempty"`
+	OperationType             *OperationType             `json:"operationType,omitempty"`
+	ProtectedItemCount        *int64                     `json:"protectedItemCount,omitempty"`
+	ResourceGroup             *string                    `json:"resourceGroup,omitempty"`
+	SourceResourceId          *string                    `json:"sourceResourceId,omitempty"`
+	StorageAccountVersion     *string                    `json:"storageAccountVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureStorageContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureStorageContainer{}
+
+func (s AzureStorageContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureStorageContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureStorageContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureStorageContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "StorageContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureStorageContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurevmappcontainerprotectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azurevmappcontainerprotectioncontainer.go
@@ -1,0 +1,64 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureVMAppContainerProtectionContainer{}
+
+type AzureVMAppContainerProtectionContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureVMAppContainerProtectionContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureVMAppContainerProtectionContainer{}
+
+func (s AzureVMAppContainerProtectionContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureVMAppContainerProtectionContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "VMAppContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureVMAppContainerProtectionContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureworkloadcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureworkloadcontainer.go
@@ -1,0 +1,64 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = AzureWorkloadContainer{}
+
+type AzureWorkloadContainer struct {
+	ExtendedInfo     *AzureWorkloadContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	LastUpdatedTime  *string                             `json:"lastUpdatedTime,omitempty"`
+	OperationType    *OperationType                      `json:"operationType,omitempty"`
+	SourceResourceId *string                             `json:"sourceResourceId,omitempty"`
+	WorkloadType     *WorkloadType                       `json:"workloadType,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s AzureWorkloadContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = AzureWorkloadContainer{}
+
+func (s AzureWorkloadContainer) MarshalJSON() ([]byte, error) {
+	type wrapper AzureWorkloadContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "AzureWorkloadContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling AzureWorkloadContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureworkloadcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_azureworkloadcontainerextendedinfo.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type AzureWorkloadContainerExtendedInfo struct {
+	HostServerName *string                 `json:"hostServerName,omitempty"`
+	InquiryInfo    *InquiryInfo            `json:"inquiryInfo,omitempty"`
+	NodesList      *[]DistributedNodesInfo `json:"nodesList,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_containeridentityinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_containeridentityinfo.go
@@ -1,0 +1,11 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ContainerIdentityInfo struct {
+	AadTenantId              *string `json:"aadTenantId,omitempty"`
+	Audience                 *string `json:"audience,omitempty"`
+	ServicePrincipalClientId *string `json:"servicePrincipalClientId,omitempty"`
+	UniqueName               *string `json:"uniqueName,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_distributednodesinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_distributednodesinfo.go
@@ -1,0 +1,11 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DistributedNodesInfo struct {
+	ErrorDetail      *ErrorDetail `json:"errorDetail,omitempty"`
+	NodeName         *string      `json:"nodeName,omitempty"`
+	SourceResourceId *string      `json:"sourceResourceId,omitempty"`
+	Status           *string      `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_dpmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_dpmcontainer.go
@@ -1,0 +1,67 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = DpmContainer{}
+
+type DpmContainer struct {
+	CanReRegister      *bool                     `json:"canReRegister,omitempty"`
+	ContainerId        *string                   `json:"containerId,omitempty"`
+	DpmAgentVersion    *string                   `json:"dpmAgentVersion,omitempty"`
+	DpmServers         *[]string                 `json:"dpmServers,omitempty"`
+	ExtendedInfo       *DPMContainerExtendedInfo `json:"extendedInfo,omitempty"`
+	ProtectedItemCount *int64                    `json:"protectedItemCount,omitempty"`
+	ProtectionStatus   *string                   `json:"protectionStatus,omitempty"`
+	UpgradeAvailable   *bool                     `json:"upgradeAvailable,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s DpmContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = DpmContainer{}
+
+func (s DpmContainer) MarshalJSON() ([]byte, error) {
+	type wrapper DpmContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling DpmContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling DpmContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "DPMContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling DpmContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_dpmcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_dpmcontainerextendedinfo.go
@@ -1,0 +1,26 @@
+package protectioncontainers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type DPMContainerExtendedInfo struct {
+	LastRefreshedAt *string `json:"lastRefreshedAt,omitempty"`
+}
+
+func (o *DPMContainerExtendedInfo) GetLastRefreshedAtAsTime() (*time.Time, error) {
+	if o.LastRefreshedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRefreshedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *DPMContainerExtendedInfo) SetLastRefreshedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRefreshedAt = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_errordetail.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_errordetail.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ErrorDetail struct {
+	Code            *string   `json:"code,omitempty"`
+	Message         *string   `json:"message,omitempty"`
+	Recommendations *[]string `json:"recommendations,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_genericcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_genericcontainer.go
@@ -1,0 +1,61 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = GenericContainer{}
+
+type GenericContainer struct {
+	ExtendedInformation *GenericContainerExtendedInfo `json:"extendedInformation,omitempty"`
+	FabricName          *string                       `json:"fabricName,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s GenericContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = GenericContainer{}
+
+func (s GenericContainer) MarshalJSON() ([]byte, error) {
+	type wrapper GenericContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling GenericContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling GenericContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "GenericContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling GenericContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_genericcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_genericcontainerextendedinfo.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type GenericContainerExtendedInfo struct {
+	ContainerIdentityInfo *ContainerIdentityInfo `json:"containerIdentityInfo,omitempty"`
+	RawCertData           *string                `json:"rawCertData,omitempty"`
+	ServiceEndpoints      *map[string]string     `json:"serviceEndpoints,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_iaasvmcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_iaasvmcontainer.go
@@ -1,0 +1,62 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = IaaSVMContainer{}
+
+type IaaSVMContainer struct {
+	ResourceGroup         *string `json:"resourceGroup,omitempty"`
+	VirtualMachineId      *string `json:"virtualMachineId,omitempty"`
+	VirtualMachineVersion *string `json:"virtualMachineVersion,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s IaaSVMContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = IaaSVMContainer{}
+
+func (s IaaSVMContainer) MarshalJSON() ([]byte, error) {
+	type wrapper IaaSVMContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling IaaSVMContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling IaaSVMContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "IaasVMContainer"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling IaaSVMContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_inquiryinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_inquiryinfo.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InquiryInfo struct {
+	ErrorDetail    *ErrorDetail              `json:"errorDetail,omitempty"`
+	InquiryDetails *[]WorkloadInquiryDetails `json:"inquiryDetails,omitempty"`
+	Status         *string                   `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_inquiryvalidation.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_inquiryvalidation.go
@@ -1,0 +1,11 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type InquiryValidation struct {
+	AdditionalDetail     *string      `json:"additionalDetail,omitempty"`
+	ErrorDetail          *ErrorDetail `json:"errorDetail,omitempty"`
+	ProtectableItemCount *interface{} `json:"protectableItemCount,omitempty"`
+	Status               *string      `json:"status,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainer.go
@@ -1,0 +1,66 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+var _ ProtectionContainer = MabContainer{}
+
+type MabContainer struct {
+	AgentVersion              *string                      `json:"agentVersion,omitempty"`
+	CanReRegister             *bool                        `json:"canReRegister,omitempty"`
+	ContainerHealthState      *string                      `json:"containerHealthState,omitempty"`
+	ContainerId               *int64                       `json:"containerId,omitempty"`
+	ExtendedInfo              *MabContainerExtendedInfo    `json:"extendedInfo,omitempty"`
+	MabContainerHealthDetails *[]MABContainerHealthDetails `json:"mabContainerHealthDetails,omitempty"`
+	ProtectedItemCount        *int64                       `json:"protectedItemCount,omitempty"`
+
+	// Fields inherited from ProtectionContainer
+
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s MabContainer) ProtectionContainer() BaseProtectionContainerImpl {
+	return BaseProtectionContainerImpl{
+		BackupManagementType:  s.BackupManagementType,
+		ContainerType:         s.ContainerType,
+		FriendlyName:          s.FriendlyName,
+		HealthStatus:          s.HealthStatus,
+		ProtectableObjectType: s.ProtectableObjectType,
+		RegistrationStatus:    s.RegistrationStatus,
+	}
+}
+
+var _ json.Marshaler = MabContainer{}
+
+func (s MabContainer) MarshalJSON() ([]byte, error) {
+	type wrapper MabContainer
+	wrapped := wrapper(s)
+	encoded, err := json.Marshal(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling MabContainer: %+v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err = json.Unmarshal(encoded, &decoded); err != nil {
+		return nil, fmt.Errorf("unmarshaling MabContainer: %+v", err)
+	}
+
+	decoded["containerType"] = "Windows"
+
+	encoded, err = json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("re-marshaling MabContainer: %+v", err)
+	}
+
+	return encoded, nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainerextendedinfo.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainerextendedinfo.go
@@ -1,0 +1,30 @@
+package protectioncontainers
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-azure-helpers/lang/dates"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MabContainerExtendedInfo struct {
+	BackupItemType   *BackupItemType `json:"backupItemType,omitempty"`
+	BackupItems      *[]string       `json:"backupItems,omitempty"`
+	LastBackupStatus *string         `json:"lastBackupStatus,omitempty"`
+	LastRefreshedAt  *string         `json:"lastRefreshedAt,omitempty"`
+	PolicyName       *string         `json:"policyName,omitempty"`
+}
+
+func (o *MabContainerExtendedInfo) GetLastRefreshedAtAsTime() (*time.Time, error) {
+	if o.LastRefreshedAt == nil {
+		return nil, nil
+	}
+	return dates.ParseAsFormat(o.LastRefreshedAt, "2006-01-02T15:04:05Z07:00")
+}
+
+func (o *MabContainerExtendedInfo) SetLastRefreshedAtAsTime(input time.Time) {
+	formatted := input.Format("2006-01-02T15:04:05Z07:00")
+	o.LastRefreshedAt = &formatted
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainerhealthdetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_mabcontainerhealthdetails.go
@@ -1,0 +1,11 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type MABContainerHealthDetails struct {
+	Code            *int64    `json:"code,omitempty"`
+	Message         *string   `json:"message,omitempty"`
+	Recommendations *[]string `json:"recommendations,omitempty"`
+	Title           *string   `json:"title,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_protectioncontainer.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_protectioncontainer.go
@@ -1,0 +1,168 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainer interface {
+	ProtectionContainer() BaseProtectionContainerImpl
+}
+
+var _ ProtectionContainer = BaseProtectionContainerImpl{}
+
+type BaseProtectionContainerImpl struct {
+	BackupManagementType  *BackupManagementType    `json:"backupManagementType,omitempty"`
+	ContainerType         ProtectableContainerType `json:"containerType"`
+	FriendlyName          *string                  `json:"friendlyName,omitempty"`
+	HealthStatus          *string                  `json:"healthStatus,omitempty"`
+	ProtectableObjectType *string                  `json:"protectableObjectType,omitempty"`
+	RegistrationStatus    *string                  `json:"registrationStatus,omitempty"`
+}
+
+func (s BaseProtectionContainerImpl) ProtectionContainer() BaseProtectionContainerImpl {
+	return s
+}
+
+var _ ProtectionContainer = RawProtectionContainerImpl{}
+
+// RawProtectionContainerImpl is returned when the Discriminated Value doesn't match any of the defined types
+// NOTE: this should only be used when a type isn't defined for this type of Object (as a workaround)
+// and is used only for Deserialization (e.g. this cannot be used as a Request Payload).
+type RawProtectionContainerImpl struct {
+	protectionContainer BaseProtectionContainerImpl
+	Type                string
+	Values              map[string]interface{}
+}
+
+func (s RawProtectionContainerImpl) ProtectionContainer() BaseProtectionContainerImpl {
+	return s.protectionContainer
+}
+
+func UnmarshalProtectionContainerImplementation(input []byte) (ProtectionContainer, error) {
+	if input == nil {
+		return nil, nil
+	}
+
+	var temp map[string]interface{}
+	if err := json.Unmarshal(input, &temp); err != nil {
+		return nil, fmt.Errorf("unmarshaling ProtectionContainer into map[string]interface: %+v", err)
+	}
+
+	var value string
+	if v, ok := temp["containerType"]; ok {
+		value = fmt.Sprintf("%v", v)
+	}
+
+	if strings.EqualFold(value, "AzureBackupServerContainer") {
+		var out AzureBackupServerContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureBackupServerContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Microsoft.ClassicCompute/virtualMachines") {
+		var out AzureIaaSClassicComputeVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureIaaSClassicComputeVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Microsoft.Compute/virtualMachines") {
+		var out AzureIaaSComputeVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureIaaSComputeVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "SQLAGWorkLoadContainer") {
+		var out AzureSQLAGWorkloadContainerProtectionContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureSQLAGWorkloadContainerProtectionContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureSqlContainer") {
+		var out AzureSqlContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureSqlContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "StorageContainer") {
+		var out AzureStorageContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureStorageContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "VMAppContainer") {
+		var out AzureVMAppContainerProtectionContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureVMAppContainerProtectionContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "AzureWorkloadContainer") {
+		var out AzureWorkloadContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into AzureWorkloadContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "DPMContainer") {
+		var out DpmContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into DpmContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "GenericContainer") {
+		var out GenericContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into GenericContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "IaasVMContainer") {
+		var out IaaSVMContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into IaaSVMContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	if strings.EqualFold(value, "Windows") {
+		var out MabContainer
+		if err := json.Unmarshal(input, &out); err != nil {
+			return nil, fmt.Errorf("unmarshaling into MabContainer: %+v", err)
+		}
+		return out, nil
+	}
+
+	var parent BaseProtectionContainerImpl
+	if err := json.Unmarshal(input, &parent); err != nil {
+		return nil, fmt.Errorf("unmarshaling into BaseProtectionContainerImpl: %+v", err)
+	}
+
+	return RawProtectionContainerImpl{
+		protectionContainer: parent,
+		Type:                value,
+		Values:              temp,
+	}, nil
+
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_protectioncontainerresource.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_protectioncontainerresource.go
@@ -1,0 +1,57 @@
+package protectioncontainers
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type ProtectionContainerResource struct {
+	ETag       *string             `json:"eTag,omitempty"`
+	Id         *string             `json:"id,omitempty"`
+	Location   *string             `json:"location,omitempty"`
+	Name       *string             `json:"name,omitempty"`
+	Properties ProtectionContainer `json:"properties"`
+	Tags       *map[string]string  `json:"tags,omitempty"`
+	Type       *string             `json:"type,omitempty"`
+}
+
+var _ json.Unmarshaler = &ProtectionContainerResource{}
+
+func (s *ProtectionContainerResource) UnmarshalJSON(bytes []byte) error {
+	var decoded struct {
+		ETag     *string            `json:"eTag,omitempty"`
+		Id       *string            `json:"id,omitempty"`
+		Location *string            `json:"location,omitempty"`
+		Name     *string            `json:"name,omitempty"`
+		Tags     *map[string]string `json:"tags,omitempty"`
+		Type     *string            `json:"type,omitempty"`
+	}
+	if err := json.Unmarshal(bytes, &decoded); err != nil {
+		return fmt.Errorf("unmarshaling: %+v", err)
+	}
+
+	s.ETag = decoded.ETag
+	s.Id = decoded.Id
+	s.Location = decoded.Location
+	s.Name = decoded.Name
+	s.Tags = decoded.Tags
+	s.Type = decoded.Type
+
+	var temp map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &temp); err != nil {
+		return fmt.Errorf("unmarshaling ProtectionContainerResource into map[string]json.RawMessage: %+v", err)
+	}
+
+	if v, ok := temp["properties"]; ok {
+		impl, err := UnmarshalProtectionContainerImplementation(v)
+		if err != nil {
+			return fmt.Errorf("unmarshaling field 'Properties' for 'ProtectionContainerResource': %+v", err)
+		}
+		s.Properties = impl
+	}
+
+	return nil
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_workloadinquirydetails.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/model_workloadinquirydetails.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+type WorkloadInquiryDetails struct {
+	InquiryValidation *InquiryValidation `json:"inquiryValidation,omitempty"`
+	ItemCount         *int64             `json:"itemCount,omitempty"`
+	Type              *string            `json:"type,omitempty"`
+}

--- a/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/version.go
+++ b/vendor/github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers/version.go
@@ -1,0 +1,10 @@
+package protectioncontainers
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See NOTICE.txt in the project root for license information.
+
+const defaultApiVersion = "2024-10-01"
+
+func userAgent() string {
+	return "hashicorp/go-azure-sdk/protectioncontainers/2024-10-01"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -44,6 +44,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/hashicorp/go-azure-helpers/lang/dates
 github.com/hashicorp/go-azure-helpers/lang/pointer
 github.com/hashicorp/go-azure-helpers/lang/response
+github.com/hashicorp/go-azure-helpers/polling
 github.com/hashicorp/go-azure-helpers/resourcemanager/commonids
 github.com/hashicorp/go-azure-helpers/resourcemanager/edgezones
 github.com/hashicorp/go-azure-helpers/resourcemanager/features
@@ -130,7 +131,9 @@ github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/p
 github.com/hashicorp/go-azure-sdk/resource-manager/paloaltonetworks/2022-08-29/prerules
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservices/2024-10-01/vaults
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotecteditems
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/backupprotectioncontainers
 github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protecteditems
+github.com/hashicorp/go-azure-sdk/resource-manager/recoveryservicesbackup/2024-10-01/protectioncontainers
 github.com/hashicorp/go-azure-sdk/resource-manager/resourcegraph/2022-10-01/resources
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2020-05-01/managementlocks
 github.com/hashicorp/go-azure-sdk/resource-manager/resources/2022-09-01/resourcegroups


### PR DESCRIPTION
Cleaned up another ~40 RGs when run on our test subscription